### PR TITLE
minor adjustments to fip

### DIFF
--- a/assets/sass/cds/_layout.scss
+++ b/assets/sass/cds/_layout.scss
@@ -6,12 +6,11 @@
 
 #fip {
   background-color: #33465c;
-  padding: 0.64rem;
-  // line-height: 0;
+  padding: 0.44rem;
 
-  @include tablet {
-    padding: 0.84rem 1.11rem;
-  }
+  // @include tablet {
+  //   padding: 0.84rem 1.11rem;
+  // }
 
   .logo {
     background-repeat: no-repeat;
@@ -83,6 +82,18 @@
       @include tablet {
         font-size: 0.84rem;
       }
+    }
+  }
+}
+
+.fip__content {
+  display: flex;
+  align-items: center;
+
+  img {
+    max-width: 52px;
+    @include desktop {
+      max-width: 58px;
     }
   }
 }

--- a/layouts/partials/fip.html
+++ b/layouts/partials/fip.html
@@ -1,6 +1,6 @@
 <div id="fip">
     <div class="container">
-        <div class="row">
+        <div class="row fip__content">
             <div class="col-sm-8 col-md-8 col-xs-12">
                 <div  style="display: flex; align-items: center;">
                     <div>
@@ -9,11 +9,7 @@
                     <div style="margin-left: 1rem;">
                         <span style="color: white;">{{ i18n "fip-header" }}</span>
                     </div>
-                    
-                    
-                </div>
-                
-                
+                </div>  
             </div>
             <div class="col-sm-4 col-md-4">
                 <section id="wb-lng" class="visible-sm visible-md visible-lg">


### PR DESCRIPTION
# Summary | Résumé

Slight adjustments on the top fip/blue banner for better centering and slightly smaller padding so it doesn't take up as much room.


| Before | After | 
|---|---|
| <img width="1449" alt="image" src="https://github.com/cds-snc/digital-canada-ca-website/assets/6607541/2a53f3b2-466d-432f-b310-8d74217d0247"> | <img width="1290" alt="image" src="https://github.com/cds-snc/digital-canada-ca-website/assets/6607541/e5f45950-d748-4d9d-9eb5-d33d8b4e185e"> |   
| <img width="645" alt="image" src="https://github.com/cds-snc/digital-canada-ca-website/assets/6607541/4be1e34c-2a36-416f-8a0e-fba286df1aec"> | <img width="648" alt="image" src="https://github.com/cds-snc/digital-canada-ca-website/assets/6607541/8678d338-5eae-49da-8c6f-b0a2f04b6dc2"> | 
