### PR TITLE
fix mobile footer

### DIFF
--- a/assets/sass/cds/_base.scss
+++ b/assets/sass/cds/_base.scss
@@ -38,7 +38,10 @@ body {
 	width: 100%;
 	// bottom: 0;
 	&.bottom {
-		bottom: 0;
+		@include desktop {
+			bottom: 0;
+		}
+		
 	}
 }
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,10 +1,9 @@
 {{ define "title"}}
-    {{ partial "menu" }}
-    <div class="page-banner" style="background-image:url('https://de2an9clyit2x.cloudfront.net/our_team_d8881d183f.jpg')">
-        <div class="page-banner--scrim"></div>
+    {{ partial "menu.html" . }}
+    <div class="page-banner sorry-error">
         <div class="container">
             <div class="page-banner--title">
-                <h1>{{ i18n "404"}}</h1>
+                <h1>{{ i18n "not-found" }}</h1>
             </div>
         </div>
     </div>
@@ -12,7 +11,7 @@
 
 {{ define "main"}}
     <div class="container">
-        <div class="content">
+        <div class="col-md-10 form-sub-section">
             {{ $path := printf "%s%s%s" "404." (string ($.Site.Language)) ".html" }}
             {{ partial  $path }}
         </div>


### PR DESCRIPTION
# Summary | Résumé

Small issue with the footer for the thank you, error and 404 pages:

![image](https://github.com/cds-snc/digital-canada-ca-website/assets/33768337/100859fd-37e5-45ab-a272-86237b3447c5)


This PR fixes the issue. Also fixed lingering outdated 404 page.