### PR TITLE
feat: add PR review environment Dockerfile

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -4,7 +4,7 @@ on:
   - pull_request
 
 env:
-  FUNCTION_NAME: "website-staging"
+  FUNCTION_NAME: "pr-review-env-*"
   GITHUB_SHA: ${{ github.sha }}
   IMAGE: website-staging-container
   REGISTRY: 521732289257.dkr.ecr.ca-central-1.amazonaws.com

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -10,6 +10,7 @@ env:
   IMAGE: website-staging-container
   REGISTRY: 521732289257.dkr.ecr.ca-central-1.amazonaws.com
   ROLE_ARN: arn:aws:iam::521732289257:role/pr-review-env-lambda
+  REGION: ca-central-1
 
 
 permissions:
@@ -36,7 +37,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::521732289257:role/pr-review-env-manage
           role-session-name: PRReviewEnv
-          aws-region: ca-central-1
+          aws-region: ${{ env.REGION }}
 
       - name: Login to ECR
         id: login-ecr
@@ -48,8 +49,8 @@ jobs:
 
       - name: Delete old images
         run: |
-          IMAGES_TO_DELETE=$( aws ecr list-images --region ca-central-1 --repository-name $IMAGE --filter "tagStatus=UNTAGGED" --query 'imageIds[*]' --output json )
-          aws ecr batch-delete-image --region ca-central-1 --repository-name $IMAGE --image-ids "$IMAGES_TO_DELETE" || true
+          IMAGES_TO_DELETE=$( aws ecr list-images --region ${{ env.REGION }} --repository-name $IMAGE --filter "tagStatus=UNTAGGED" --query 'imageIds[*]' --output json )
+          aws ecr batch-delete-image --region ${{ env.REGION }} --repository-name $IMAGE --image-ids "$IMAGES_TO_DELETE" || true
 
       - name: Logout of Amazon ECR
         run: docker logout $REGISTRY
@@ -69,7 +70,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::521732289257:role/pr-review-env-manage
           role-session-name: PRReviewEnv
-          aws-region: ca-central-1
+          aws-region: ${{ env.REGION }}
 
       - name: Create/Update lambda function
         run: |

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,10 +1,11 @@
 name: Staging review apps
 
 on:
-  - pull_request
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 env:
-  FUNCTION_NAME: "pr-review-env-*"
+  FUNCTION_NAME: "pr-review-env"
   GITHUB_SHA: ${{ github.sha }}
   IMAGE: website-staging-container
   REGISTRY: 521732289257.dkr.ecr.ca-central-1.amazonaws.com

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,100 @@
+name: Staging review apps
+
+on:
+  - pull_request
+
+env:
+  FUNCTION_NAME: "website-staging"
+  GITHUB_SHA: ${{ github.sha }}
+  IMAGE: website-staging
+  REGISTRY: 521732289257.dkr.ecr.ca-central-1.amazonaws.com
+  ROLE_ARN: arn:aws:iam::521732289257:role/website-staging-execution-role
+
+jobs:
+  build-and-push-staging-container:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set envs
+        run: echo "PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")" >> $GITHUB_ENV
+
+      - name: Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - name: Build container
+        run: |
+          docker build -t $REGISTRY/$IMAGE:$PR_NUMBER .
+
+      - name: Configure AWS credentials using OIDC
+        id: aws-creds
+        uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0 # v3.0.2
+        with:
+          aws-access-key-id: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
+      - name: Login to ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@2fc7aceee09e9e4a7105c0d060c656fad0b4f63d # v1.7.0
+
+      - name: Push containers to ECR
+        run: |
+          docker push $REGISTRY/$IMAGE:$PR_NUMBER
+
+      - name: Delete old images
+        run: |
+          IMAGES_TO_DELETE=$( aws ecr list-images --region ca-central-1 --repository-name $IMAGE --filter "tagStatus=UNTAGGED" --query 'imageIds[*]' --output json )
+          aws ecr batch-delete-image --region ca-central-1 --repository-name $IMAGE --image-ids "$IMAGES_TO_DELETE" || true
+
+      - name: Logout of Amazon ECR
+        run: docker logout $REGISTRY
+
+  deploy-staging-images:
+    needs: build-and-push-staging-container
+    strategy:
+      matrix:
+        lang: ["fr", "en"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set envs
+        run: echo "PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")" >> $GITHUB_ENV
+
+      - name: Configure AWS credentials
+        id: aws-creds
+        uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0 # v3.0.2
+        with:
+          aws-access-key-id: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
+      - name: Create/Update lambda function
+        run: |
+          if aws lambda get-function --function-name $FUNCTION_NAME-$PR_NUMBER-${{ matrix.lang }} > /dev/null 2>&1; then
+            aws lambda update-function-code \
+              --function-name $FUNCTION_NAME-$PR_NUMBER-${{ matrix.lang }} \
+              --image-uri $REGISTRY/$IMAGE:$PR_NUMBER > /dev/null 2>&1
+          else
+            aws lambda create-function \
+              --function-name $FUNCTION_NAME-$PR_NUMBER-${{ matrix.lang }} \
+              --package-type Image \
+              --role $ROLE_ARN \
+              --code ImageUri=$REGISTRY/$IMAGE:$PR_NUMBER \
+              --environment Variables={CONTENT_DIR=/var/www/html/${{ matrix.lang }}} \
+              --description "$GITHUB_REPOSITORY/pull/$PR_NUMBER"
+
+            aws lambda wait function-active --function-name $FUNCTION_NAME-$PR_NUMBER-${{ matrix.lang }}
+            echo URL=$(aws lambda create-function-url-config --function-name $FUNCTION_NAME-$PR_NUMBER-${{ matrix.lang }} --auth-type NONE | jq .FunctionUrl) >> $GITHUB_ENV
+            aws lambda add-permission --function-name $FUNCTION_NAME-$PR_NUMBER-${{ matrix.lang }} --statement-id FunctionURLAllowPublicAccess --action lambda:InvokeFunctionUrl --principal "*" --function-url-auth-type NONE > /dev/null 2>&1
+          fi
+
+      - name: Update PR
+        if: env.URL != ''
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## :test_tube: Review environment (${{ matrix.lang }})\n${process.env.URL.slice(1, -1)}`
+            })

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -6,9 +6,15 @@ on:
 env:
   FUNCTION_NAME: "website-staging"
   GITHUB_SHA: ${{ github.sha }}
-  IMAGE: website-staging
+  IMAGE: website-staging-container
   REGISTRY: 521732289257.dkr.ecr.ca-central-1.amazonaws.com
-  ROLE_ARN: arn:aws:iam::521732289257:role/website-staging-execution-role
+  ROLE_ARN: arn:aws:iam::521732289257:role/pr-review-env-manage
+
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write  
 
 jobs:
   build-and-push-staging-container:
@@ -18,23 +24,22 @@ jobs:
         run: echo "PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")" >> $GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Build container
         run: |
           docker build -t $REGISTRY/$IMAGE:$PR_NUMBER .
 
       - name: Configure AWS credentials using OIDC
-        id: aws-creds
-        uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0 # v3.0.2
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
-          aws-access-key-id: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::521732289257:role/pr-review-env-manage
+          role-session-name: PRReviewEnv
           aws-region: ca-central-1
 
       - name: Login to ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@2fc7aceee09e9e4a7105c0d060c656fad0b4f63d # v1.7.0
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
 
       - name: Push containers to ECR
         run: |
@@ -58,12 +63,11 @@ jobs:
       - name: Set envs
         run: echo "PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")" >> $GITHUB_ENV
 
-      - name: Configure AWS credentials
-        id: aws-creds
-        uses: aws-actions/configure-aws-credentials@50ac8dd1e1b10d09dac7b8727528b91bed831ac0 # v3.0.2
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
-          aws-access-key-id: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::521732289257:role/pr-review-env-manage
+          role-session-name: PRReviewEnv
           aws-region: ca-central-1
 
       - name: Create/Update lambda function
@@ -88,7 +92,7 @@ jobs:
 
       - name: Update PR
         if: env.URL != ''
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -9,7 +9,7 @@ env:
   GITHUB_SHA: ${{ github.sha }}
   IMAGE: website-staging-container
   REGISTRY: 521732289257.dkr.ecr.ca-central-1.amazonaws.com
-  ROLE_ARN: arn:aws:iam::521732289257:role/pr-review-env-manage
+  ROLE_ARN: arn:aws:iam::521732289257:role/pr-review-env-lambda
 
 
 permissions:

--- a/.github/workflows/remove-staging.yml
+++ b/.github/workflows/remove-staging.yml
@@ -5,7 +5,7 @@ on:
     types: [closed]
 
 env:
-  FUNCTION_NAME: "website-staging"
+  FUNCTION_NAME: "pr-review-env"
   GITHUB_SHA: ${{ github.sha }}
   IMAGE: website-staging-container
   REGISTRY: 521732289257.dkr.ecr.ca-central-1.amazonaws.com

--- a/.github/workflows/remove-staging.yml
+++ b/.github/workflows/remove-staging.yml
@@ -1,0 +1,53 @@
+name: Staging review apps tear down
+
+on:
+  pull_request:
+    types: [closed]
+
+env:
+  FUNCTION_NAME: "website-staging"
+  GITHUB_SHA: ${{ github.sha }}
+  IMAGE: website-staging-container
+  REGISTRY: 521732289257.dkr.ecr.ca-central-1.amazonaws.com
+  ROLE_ARN: arn:aws:iam::521732289257:role/pr-review-env-manage
+
+jobs:
+  remove-staging-containers:
+    strategy:
+      matrix:
+        lang: ["fr", "en"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set envs
+        run: echo "PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")" >> $GITHUB_ENV
+
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+        with:
+          role-to-assume: arn:aws:iam::521732289257:role/pr-review-env-manage
+          role-session-name: PRReviewEnv
+          aws-region: ca-central-1
+
+      - name: Delete lambda function
+        run: |
+          sleep 4m
+          aws lambda delete-function-url-config --function-name $FUNCTION_NAME-$PR_NUMBER-${{ matrix.lang }}
+          aws lambda delete-function --function-name $FUNCTION_NAME-$PR_NUMBER-${{ matrix.lang }}
+          aws logs delete-log-group --log-group-name /aws/lambda/$FUNCTION_NAME-$PR_NUMBER-${{ matrix.lang }}
+
+  delete-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set envs
+        run: echo "PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")" >> $GITHUB_ENV
+
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+        with:
+          role-to-assume: arn:aws:iam::521732289257:role/pr-review-env-manage
+          role-session-name: PRReviewEnv
+          aws-region: ca-central-1
+
+      - name: Delete old images
+        run: |
+          aws ecr batch-delete-image --region ca-central-1 --repository-name $IMAGE --image-ids imageTag=$PR_NUMBER

--- a/.github/workflows/remove-staging.yml
+++ b/.github/workflows/remove-staging.yml
@@ -9,7 +9,7 @@ env:
   GITHUB_SHA: ${{ github.sha }}
   IMAGE: website-staging-container
   REGISTRY: 521732289257.dkr.ecr.ca-central-1.amazonaws.com
-  ROLE_ARN: arn:aws:iam::521732289257:role/pr-review-env-manage
+  REGION: ca-central-1
 
 jobs:
   remove-staging-containers:
@@ -26,7 +26,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::521732289257:role/pr-review-env-manage
           role-session-name: PRReviewEnv
-          aws-region: ca-central-1
+          aws-region: ${{ env.REGION }}
 
       - name: Delete lambda function
         run: |
@@ -46,8 +46,8 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::521732289257:role/pr-review-env-manage
           role-session-name: PRReviewEnv
-          aws-region: ca-central-1
+          aws-region: ${{ env.REGION }}
 
       - name: Delete old images
         run: |
-          aws ecr batch-delete-image --region ca-central-1 --repository-name $IMAGE --image-ids imageTag=$PR_NUMBER
+          aws ecr batch-delete-image --region ${{ env.REGION }} --repository-name $IMAGE --image-ids imageTag=$PR_NUMBER

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ public/*
 resources/*
 .DS_Store
 deploy.md
-Dockerfile
 backstop_data/html_report/
 bitmaps_test/
 **/.terragrunt-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM debian:buster-slim@sha256:836de3c09762be6f729e0e3295dbf66de9232894d330bbbf7a78d19b704df8fa as build 
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install wget \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG HUGO_VERSION="0.55.6"
+RUN wget "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz" \
+    && tar -xvf hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz hugo \
+    && mv  hugo /usr/bin \
+    && rm hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz
+
+ADD https://github.com/cds-snc/static-content-lambda/raw/main/release/latest/lambda-static-server /lambda-static-server
+RUN chmod 755 /lambda-static-server
+
+COPY ./ /site
+WORKDIR /site
+RUN hugo
+
+FROM scratch
+
+COPY --from=build /site/public /var/www/html
+COPY --from=build /lambda-static-server /lambda-static-server
+
+ENTRYPOINT [ "/lambda-static-server" ]

--- a/terragrunt/aws/ecr/ecr.tf
+++ b/terragrunt/aws/ecr/ecr.tf
@@ -1,6 +1,6 @@
 resource "aws_ecr_repository" "website_staging_container" {
   name                 = "website-staging-container"
-  image_tag_mutability = "IMMUTABLE"
+  image_tag_mutability = "MUTABLE"
   image_scanning_configuration {
     scan_on_push = true
   }

--- a/terragrunt/aws/ecr/iam_oidc.tf
+++ b/terragrunt/aws/ecr/iam_oidc.tf
@@ -39,6 +39,7 @@ data "aws_iam_policy_document" "lambda_function_manage" {
   statement {
     effect = "Allow"
     actions = [
+      "lambda:AddPermission",
       "lambda:CreateFunction",
       "lambda:CreateFunctionUrlConfig",
       "lambda:DeleteFunction",


### PR DESCRIPTION
# Summary 
Add a Dockerfile and workflows that can be used to create PR review environments for all website changes.

Also fixes the OIDC IAM role permissions and makes the ECR `mutable` to allow for a re-push of the PR's Docker image.

# Related
- Closes https://github.com/cds-snc/platform-core-services/issues/506