### PR TITLE
fix: update staging tear down workflow perms

### DIFF
--- a/.github/workflows/remove-staging.yml
+++ b/.github/workflows/remove-staging.yml
@@ -11,6 +11,9 @@ env:
   REGISTRY: 521732289257.dkr.ecr.ca-central-1.amazonaws.com
   REGION: ca-central-1
 
+permissions:
+  id-token: write
+
 jobs:
   remove-staging-containers:
     strategy:


### PR DESCRIPTION
# Summary 
Add the `id-token` write permission to the workflow so that it can assume the OIDC role.