### PR TITLE
remove text in fip banner, leaving only language toggle

### DIFF
--- a/layouts/partials/fip.html
+++ b/layouts/partials/fip.html
@@ -1,17 +1,7 @@
 <div id="fip">
     <div class="container">
         <div class="row fip__content">
-            <div class="col-sm-8 col-md-8 col-xs-12">
-                <div  style="display: flex; align-items: center;">
-                    <div>
-                        <img alt="{{ i18n "fip-logo-alt"}}" src="/img/cds/Flag.svg" />
-                    </div>
-                    <div style="margin-left: 1rem;">
-                        <span style="color: white;">{{ i18n "fip-header" }}</span>
-                    </div>
-                </div>  
-            </div>
-            <div class="col-sm-4 col-md-4">
+            <div class="col-sm-12 col-md-12">
                 <section id="wb-lng" class="visible-sm visible-md visible-lg">
                     <h2>{{ i18n "language-selection" }}</h2>
                     <div id="lang" class="lang">


### PR DESCRIPTION
# Summary

Removing the logo and text in the top blue banner (leaving only the language toggle), per some feedback recieved, and as outlined in [this trello card](https://trello.com/c/ZO9YTks3/568-feature-request-brand-position-of-official-symbols)

| Before | After |   
|--------|-------|
| ![image](https://github.com/cds-snc/digital-canada-ca-website/assets/6607541/d029af1f-8565-43ce-aab9-02c7c152191e) | ![image](https://github.com/cds-snc/digital-canada-ca-website/assets/6607541/994a1771-8ba1-40d9-b756-4a786b518275) |
