### PR TITLE
integrate gcds header, adjust containers accordingly so content matches

### DIFF
--- a/assets/sass/cds/_base.scss
+++ b/assets/sass/cds/_base.scss
@@ -16,13 +16,18 @@
 // CDS Base Styles and Style Overrides
 html {
 	// This sets the base font size as 1.125rem or 18px. 
-	font-size: 18px; 
+	// font-size: 18px; 
 	scroll-behavior: smooth;
 	height: 100%;
 	position: relative;
 }
 
+:root {
+	font-size: 16px;
+}
+
 body, h1, h2, h3, h4, h5, h6, p, ul, ol, li, a {
+	// font-size: 18px;
 	font-family	: "SourceSansPro", sans-serif !important;
 }
 
@@ -36,6 +41,16 @@ body {
 .footer {
 	position: absolute;
 	width: 100%;
+}
+
+//addressing the forced margin on gcds header menu
+header[role=banner] {
+	margin-bottom: -0.75rem;
+
+	.page-banner {
+		margin-top: -0.75rem;
+		margin-bottom: 0.75rem;
+	}
 }
 
 a {
@@ -135,7 +150,9 @@ h3 {
 }
 
 html .container {
-	width: 70%;
+	width: 100%;
+	// temporary calc to account for the padding that column classes have
+	max-width: calc(71.25rem + 30px);
 
 	@include mobile_only {
 		width: 100%;
@@ -186,7 +203,7 @@ html .container {
 
 .row {
 	width: 100%;
-	margin: 0 auto;
+	// margin: 0 auto;
 }
 
 input.error {

--- a/assets/sass/cds/_mixins.scss
+++ b/assets/sass/cds/_mixins.scss
@@ -6,7 +6,7 @@
 @mixin sm_desktop_screen {@media ( max-width: 950px ) { @content; } }
 
 // the following mixins are meant to address content changes on our header menus 
-@mixin menu_break { @media (min-width: 1342px) { @content; } }
+@mixin menu_break { @media (min-width: 1024px) { @content; } }
 @mixin logo_break { @media (max-width: 1341px) { @content; } }
 @mixin tablet_break { @media (max-width: 768px) { @content; } }
 @mixin retina {

--- a/assets/sass/cds/_nav.scss
+++ b/assets/sass/cds/_nav.scss
@@ -40,25 +40,26 @@
   display: block;
   
 
-  @include mobile_only {
-    height: 2.78rem;
-    width: 11.11rem;
-    display: none;
-  }
+  // @include mobile_only {
+  //   height: 2.78rem;
+  //   width: 11.11rem;
+  //   display: none;
+  // }
 
   // added the below custom mixin to address menu content changes
-  @include logo_break {
-    height: 2.78rem;
-    width: 12.5rem;
-    position: absolute;
-    top: 0;
-  }
+  // @include logo_break {
+  //   height: 2.78rem;
+  //   width: 12.5rem;
+  //   position: absolute;
+  //   top: 0;
+  // }
 
   @include menu_break {
     height: 2.78rem;
     width: 13.88rem;
     position: absolute;
-    top: -1.11rem;
+    // top: -1.11rem;
+    top: 0.5rem;
   }
 
   // BILINGUAL SPECIFIC CDS LOGO
@@ -80,9 +81,9 @@
     height: 2.5rem;
     width: 2.5rem;
     
-    @include mobile_only {
-      display: block;
-    }
+    // @include mobile_only {
+    //   display: block;
+    // }
 
   // BILINGUAL SPECIFIC CDS LOGO - MOBILE SCREEN
   &.en {
@@ -101,6 +102,7 @@
 
 .menu-items {
   padding: 0;
+  display: flex;
   // text-align: right;
   @include mobile_only {
     text-align: center;

--- a/assets/sass/cds/_sections.scss
+++ b/assets/sass/cds/_sections.scss
@@ -63,6 +63,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+
     a {
       color: $white;
     }

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,5 +1,5 @@
 {{ define "title"}}
-    {{ partial "menu.html" . }}
+    <!-- {{ partial "menu.html" . }} -->
     <div class="page-banner sorry-error">
         <div class="container">
             <div class="page-banner--title">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -99,10 +99,12 @@
     </nav>
     
     <header role="banner">
-      {{ partial "fip.html" . }}
+      <!-- {{ partial "fip.html" . }} -->
+      {{ partial "header.html" . }}
+
 
       {{ block "title" . }}
-      {{partial "menu.html" . }}
+      <!-- {{partial "menu.html" . }} -->
       {{ if or (eq .Params.title "Error") (eq .Params.title "Erreur!") }}
       <div class="page-banner error">
       {{ else }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,5 +1,5 @@
 {{ define "title"}}
-    {{ partial "menu.html" . }}
+    <!-- {{ partial "menu.html" . }} -->
     <div class="page-banner sorry-error">
         <div class="container">
             <div class="page-banner--title">

--- a/layouts/a11y/default.html
+++ b/layouts/a11y/default.html
@@ -56,10 +56,11 @@
     </nav>
 
     <header role="banner">
-      {{ partial "fip.html" . }}
+      <!-- {{ partial "fip.html" . }} -->
+      {{ partial "header.html" . }}
 
       {{ block "title" . }}
-        {{partial "menu.html" . }}
+        <!-- {{partial "menu.html" . }} -->
         <div class="page-banner">
           <div class="container">
             <div class="page-banner--title">

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -1,5 +1,5 @@
 {{define "title"}}
-{{partial "menu.html" . }}
+<!-- {{partial "menu.html" . }} -->
 {{ with .Params.imagealt }}
 <!-- <div class="page-banner" role="img" aria-label="{{ .Params.imagealt }}" style="background-image: url('{{ .Params.image }}')"></div> -->
 {{ else }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,5 +1,5 @@
 {{ define "title" }}
-{{ partial "menu.html" . }}
+<!-- {{ partial "menu.html" . }} -->
 {{ end }}
 
 {{ define "index" }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,0 +1,17 @@
+<gcds-header lang-href="#" skip-to-href="#">
+    <gcds-top-nav
+        label="Top navigation"
+        alignment="right"
+        slot="menu"
+>
+        <gcds-nav-link href={{ .Site.BaseURL | absLangURL }} class="cds-logo {{.Site.Language.Lang}}" slot="home" slot="left" aria-label="{{ i18n "aria-cds-website" }}" id="cds-logo" ></gcds-nav-link>
+        <!-- mobile screen wordless logo -->
+        <gcds-nav-link href={{ .Site.BaseURL | absLangURL }} class="cds-logo-mobile {{.Site.Language.Lang}}" slot="home" slot="left" aria-label="{{ i18n "aria-cds-website" }}"></gcds-nav-link>
+
+
+        {{ $title := .Params.title }}
+        {{ range $menu := .Site.Menus.main }}
+        <gcds-nav-link href="{{ .URL | relLangURL }}" id="{{.Identifier}}-nav-tag" class="menu-items-a" {{ if eq $title .Identifier }} current{{end}}>{{ .Name }} </gcds-nav-link>
+        {{ end }}
+    </gcds-top-nav>
+</gcds-header>


### PR DESCRIPTION
# Summary | Résumé

Blog list page summary and author and date were not in any span or paragraph tag. Added those in for accessibility, and bumped the margin after author name slightly for a little more seperation.

<img width="969" alt="image" src="https://github.com/cds-snc/digital-canada-ca-website/assets/6607541/0c77fb67-2a61-4c97-b75b-11745e34bb8e">

