### PR TITLE
add paragraph element around blog summary and span to author and date

### DIFF
--- a/assets/sass/cds/_sections.scss
+++ b/assets/sass/cds/_sections.scss
@@ -414,6 +414,7 @@
   .author {
     font-size: 1rem;
     font-weight: 600;
+    margin-bottom: 0.65rem;
 
     @include tablet {
       // This rule will limit the number of lines to 3

--- a/static/js/blog.js
+++ b/static/js/blog.js
@@ -46,10 +46,10 @@ function renderBlogResults(blogs) {
                         </a>
                     </div>
                     <div class="date">
-                        ${dateFormat(paginatedBlogs[i].date)}
+                        <span>${dateFormat(paginatedBlogs[i].date)}</span>
                     </div>
-                    <div class="author">${paginatedBlogs[i].author}</div>
-                    <div class="summary">${paginatedBlogs[i].description}</div>
+                    <div class="author"><span>${paginatedBlogs[i].author}</span></div>
+                    <div class="summary"><p>${paginatedBlogs[i].description}</p></div>
                     <gcds-button size="small" button-id="read-full-post-btn" type="link" href='${paginatedBlogs[i].href}'>${readFullPostTranslation()}<span style="display: none">: ${paginatedBlogs[i].title}</span> <gcds-icon name="fa-solid fa-chevron-right" size="inherit"></gcds-icon></gcds-button>
                 </div>
         </li>`


### PR DESCRIPTION
# Summary | Résumé

Blog list page summary and author and date were not in any span or paragraph tag. Added those in for accessibility, and bumped the margin after author name slightly for a little more seperation.

<img width="969" alt="image" src="https://github.com/cds-snc/digital-canada-ca-website/assets/6607541/0c77fb67-2a61-4c97-b75b-11745e34bb8e">