### PR TITLE
Content updates to webpages

### DIFF
--- a/content/en/about-us.html
+++ b/content/en/about-us.html
@@ -27,8 +27,8 @@ aliases: [/meet-the-team/, /coaching-and-advice/]
                 <h2>Who we are</h2>
                 <p>We're a team of over 100 people. We work across Canada, from coast to coast to coast.</p>
                 <ul>
-                    <li><a href="https://digital.canada.ca/2017/07/18/launch-of-the-canadian-digital-service/">In 2017, we were founded</a> in Treasury Board of Canada Secretariat (TBS). </li>
-                    <li><a href="https://www.budget.canada.ca/2021/report-rapport/p4-en.html">In budget 2021, we received ongoing funding</a> to become a permanent organization in the Government of Canada.</li>
+                    <li><a href="https://digital.canada.ca/2017/07/18/launch-of-the-canadian-digital-service/">In 2017, we were created</a> by the Treasury Board of Canada Secretariat (TBS). </li>
+                    <li><a href="https://www.budget.canada.ca/2021/report-rapport/p4-en.html">In the 2021 Budget, we received ongoing funding</a> to become a permanent organization in the Government of Canada.</li>
                     <li><a href="https://orders-in-council.canada.ca/attachment.php?attach=44098&lang=en">In 2023, we moved from TBS to ESDC</a> to support the new Minister of Citizen Services. </li>
                 </ul>
             </div>

--- a/content/fr/about-us.html
+++ b/content/fr/about-us.html
@@ -8,12 +8,12 @@ aliases: [/recontrez-lequipe/, /encadrement-et-conseil/]
 <section class="container">
     <div class="row" style="padding: 4.5rem 0 2rem 0">
         <div class="col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1 col-xs-12">
-            <p>Le Service numérique canadien (SNC) fait partie d<a href="https://www.canada.ca/fr/emploi-developpement-social.html">’Emploi et développement social Canada</a>(ESDC).
+            <p>Le Service numérique canadien (SNC) fait partie d<a href="https://www.canada.ca/fr/emploi-developpement-social.html">’Emploi et développement social Canada</a> (EDSC).
                  Nous cherchons à nous rapprocher des objectifs de l’<a href="https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/plans-strategiques-operations-numeriques-gouvernement-canada/ambition-numerique-canada.html">Ambition numérique</a> et à améliorer les expériences liées au service au sein du gouvernement du Canada.
             </p>
             
             <div style="margin-bottom: 1.75rem;">
-                <h2>Ce que fait le SNC :</h2>
+                <h2>Ce que fait le SNC</h2>
                 <p>Nous aidons les ministères à améliorer l’expérience utilisateur et à accélérer la livraison des projets afin de soutenir les priorités des services fédéraux.</p>
                 <p>Nous créons des produits numériques répondant aux problèmes auxquels font généralement face les services ministériels. Ces produits sont accessibles à <a href="/">l’ensemble des fonctionnaires du gouvernement fédéral.</a> </p>
                 

--- a/content/fr/terms.html
+++ b/content/fr/terms.html
@@ -54,7 +54,7 @@ aliases: [/transparence/avis/, /terms/]
 				communiquer leurs renseignements personnels.</p>
 			
 			<h2>Propri&eacute;t&eacute; et utilisation du contenu offert dans ce site</h2>
-			<p>Le contenu de ce site Web a &eacute;t&eacute; produit ou rassembl&eacute; afin d'offrir aux Canadiens
+			<p>Le contenu de ce site Web a &eacute;t&eacute; produit ou rassembl&eacute; afin d'offrir aux Canadien·ne·s
 				l'acc&egrave;s aux renseignements concernant le Service num&eacute;rique canadien. Vous pouvez utiliser
 				et reproduire le contenu des fa&ccedil;ons suivantes&nbsp;:</p>
 			<h3>Reproduction non commerciale</h3>

--- a/layouts/section/jobs.fr.html
+++ b/layouts/section/jobs.fr.html
@@ -10,7 +10,7 @@
                 <p>Au SNC, vous ferez partie d'une équipe qui travaille à la prestation de services importants qui
                     aident les gens.</p>
                 <p>Vous pouvez travailler de n'importe où au Canada, selon un horaire flexible qui vous permettra de
-                    maintenir un bon équilibre entre la vie professionnelle et privée. Nos employés se trouvent partout
+                    maintenir un bon équilibre entre la vie professionnelle et privée. Nos employé·e·s se trouvent partout
                     au pays, d'un océan à l'autre.</p>
                 <p>Nous mettons à votre disposition des outils et technologies de fine pointe pour vous aider à faire un
                     excellent travail.</p>
@@ -79,10 +79,10 @@
                         public que nous servons. C’est en tirant parti de diverses perspectives, expériences et
                         compétences que nous pourrons offrir des services publics de meilleure qualité, plus accessibles
                         et plus inclusifs. Nous travaillons fort pour créer un environnement où différentes perspectives
-                        et expériences sont valorisées, Nous nous engageons à aider les talents de tout type à
+                        et expériences sont valorisées. Nous nous engageons à aider les talents de tout type à
                         s’épanouir.</p>
 
-                    <p class="mrgn-bttm-0">Le SNC accueille tous les candidats, peu importe leur race, ethnicité, religion, orientation
+                    <p class="mrgn-bttm-0">Le SNC accueille tous les candidat·e·s, peu importe leur race, ethnicité, religion, orientation
                         sexuelle, identité et expression de genre, origine nationale, handicap, âge et taille
                         corporelle, y compris les vétérans et les personnes qui ont des engagements familiaux divers.
                     </p>


### PR DESCRIPTION
**English:**
Page: [About](https://digital.canada.ca/about/)
Suggestion 1: Change text for grammar: from “In 2017, we were founded in TBS” to “In 2017, we were founded under the Treasury Board...“; 
Suggestion 2: from “In budget 2021” to “In the 2021 Budget” or “As a part of Budget 2021” (any capitalization helps show that it’s an awkward proper noun)

**French:**
Page: [À propos](https://numerique.canada.ca/a-propos/)
Suggestion 1: Change acronym in first line from ESDC to EDSC and add space; only ‘Ce que fait’ has a semi-colon but none of the other subheadings

Page: [Emplois](https://numerique.canada.ca/emplois/)
Suggestion 1: consistency in using doublets for genders (used for candidat·e·s but missing for nos employés, tous les candidats, (maybe more?))
Suggestion 2: replace the comma with a period in "sont valorisées, Nous nous engageons à aider"

Page: [Avis](https://numerique.canada.ca/avis/)
Suggestion 1: d'offrir aux Canadiens l'accès to “Canadien·ne·s”
