### PR TITLE
Set max height on blog images

### DIFF
--- a/assets/sass/cds/_mixins.scss
+++ b/assets/sass/cds/_mixins.scss
@@ -6,9 +6,6 @@
 @mixin sm_desktop_screen {@media ( max-width: 950px ) { @content; } }
 
 // the following mixins are meant to address content changes on our header menus 
-@mixin menu_break { @media (min-width: 1024px) { @content; } }
-@mixin logo_break { @media (max-width: 1341px) { @content; } }
-@mixin tablet_break { @media (max-width: 768px) { @content; } }
 @mixin retina {
 	@media
 		only screen and (-webkit-min-device-pixel-ratio: 2),

--- a/assets/sass/cds/_sections.scss
+++ b/assets/sass/cds/_sections.scss
@@ -373,25 +373,6 @@
     }
   }
 
-
-  .photo-container {
-    height: 250px;
-    width: 100%;
-
-    @include logo_break {
-      height: 200px;
-    }
-  }
-
-  .photo {
-    display: inline-block;
-    height: 100%;
-    width: 100%;
-    background-size: cover;
-    background-position: center center;
-    background-repeat: no-repeat;
-  }
-
   .text {
     line-height: 1.4;
   }
@@ -504,6 +485,10 @@ article.post {
     display: block;
     margin-right: auto;
     margin-left: auto;
+
+    @include tablet {
+      max-height: 450px;
+    }
   }
 
   a.large-link {
@@ -516,11 +501,6 @@ article.post {
     font-weight: 600;
     font-size: 0.84rem;
     margin: 0rem 0 1.11rem 0;
-
-    .post-title-container {
-      // padding: 25px 0;
-      
-    }
 
     time {
       display: block;


### PR DESCRIPTION
# Summary | Résumé

This is to prevent them "blowing up" on certain screen sizes, which was some feedback we received.
Also cleaned up a bit more unused CSS (mixins for the old site, a photo class that no longer is in use)

| Before | After |
|--------|-------|
| <img width="1786" alt="image" src="https://github.com/cds-snc/digital-canada-ca-website/assets/6607541/d2c22da7-2d1f-4f4d-81f6-7ea934bb05ca">  | <img width="1782" alt="image" src="https://github.com/cds-snc/digital-canada-ca-website/assets/6607541/5d87fdf8-1e26-41a9-b5af-a2fa2869d2a2"> |
