### PR TITLE
Make Read full Post button on Blog page to secondary

### DIFF
--- a/layouts/section/blog.html
+++ b/layouts/section/blog.html
@@ -18,7 +18,7 @@
     </div>
     <div class="container" style="display: flex; flex-direction: column;">
         <div style="margin-left: auto; margin-right: auto; margin-bottom: 2rem;">
-            <gcds-button id="blog-btn" button-id="load-more-blog-btn">{{ i18n "load-more"}} <gcds-icon
+            <gcds-button id="blog-btn" button-role="secondary" button-id="load-more-blog-btn">{{ i18n "load-more"}} <gcds-icon
                     name="fa-solid fa-chevron-right fa-rotate-90"></gcds-icon></gcds-button>
         </div>
     </div>

--- a/layouts/section/blog.html
+++ b/layouts/section/blog.html
@@ -18,7 +18,7 @@
     </div>
     <div class="container" style="display: flex; flex-direction: column;">
         <div style="margin-left: auto; margin-right: auto; margin-bottom: 2rem;">
-            <gcds-button id="blog-btn" button-role="secondary" button-id="load-more-blog-btn">{{ i18n "load-more"}} <gcds-icon
+            <gcds-button id="blog-btn" button-id="load-more-blog-btn">{{ i18n "load-more"}} <gcds-icon
                     name="fa-solid fa-chevron-right fa-rotate-90"></gcds-icon></gcds-button>
         </div>
     </div>

--- a/static/js/blog.js
+++ b/static/js/blog.js
@@ -48,7 +48,7 @@ function renderBlogResults(blogs) {
                     </div>
                     <div class="author"><span>${paginatedBlogs[i].author}</span></div>
                     <div class="summary"><p>${paginatedBlogs[i].description}</p></div>
-                    <gcds-button size="small" button-id="read-full-post-btn" type="link" href='${paginatedBlogs[i].href}'>${readFullPostTranslation()}<span style="display: none">: ${paginatedBlogs[i].title}</span> <gcds-icon name="fa-solid fa-chevron-right" size="inherit"></gcds-icon></gcds-button>
+                    <gcds-button size="small" button-role="secondary" button-id="read-full-post-btn" type="link" href='${paginatedBlogs[i].href}'>${readFullPostTranslation()}<span style="display: none">: ${paginatedBlogs[i].title}</span> <gcds-icon name="fa-solid fa-chevron-right" size="inherit"></gcds-icon></gcds-button>
                 </div>
         </li>`
     }


### PR DESCRIPTION
# Summary | Résumé

Part of the feedback to the website team was that we should use a secondary button type on the blog page, between the read more buttons and the load more at the bottom of the page. I have made the read more button a secondary button type.

| Before | After |
|--------|-------|
|    <img width="1057" alt="image" src="https://github.com/cds-snc/digital-canada-ca-website/assets/6607541/8ecb86b6-e42d-4770-a4c3-f9f69bff1307">    |  <img width="1023" alt="image" src="https://github.com/cds-snc/digital-canada-ca-website/assets/6607541/01ddf69f-6480-404d-985e-b0d92e9a93db">  |



