### PR TITLE
fixed field for url samples

### DIFF
--- a/layouts/section/job-posting.en.html
+++ b/layouts/section/job-posting.en.html
@@ -94,7 +94,7 @@
           <input type="text" class="form-control" id="samples" name="samples" />
         </div> -->
         <gcds-input input-id="samples" label="Samples of your work (URL)"
-          hint="Share with us any relevant URLs showcasing your work" type="url" size="35">
+          hint="Share with us any relevant URLs showcasing your work" size="35">
         </gcds-input>
 
         <!-- How did you hear about this job-->

--- a/layouts/section/job-posting.en.html
+++ b/layouts/section/job-posting.en.html
@@ -94,7 +94,7 @@
           <input type="text" class="form-control" id="samples" name="samples" />
         </div> -->
         <gcds-input input-id="samples" label="Samples of your work (URL)"
-          hint="Share with us any relevant URLs showcasing your work" size="35">
+          hint="Share with us any relevant URLs showcasing your work" size="100">
         </gcds-input>
 
         <!-- How did you hear about this job-->

--- a/layouts/section/job-posting.fr.html
+++ b/layouts/section/job-posting.fr.html
@@ -90,7 +90,7 @@
           </div>
           <input type="text" class="form-control" id="samples" name="samples" />
         </div> -->
-        <gcds-input input-id="samples" label="Exemples de travaux (URL)" type="url"
+        <gcds-input input-id="samples" label="Exemples de travaux (URL)"
           hint="Indiquez toute URL pertinente présentant votre travail." size="35" lang="fr">
         </gcds-input>
 

--- a/layouts/section/job-posting.fr.html
+++ b/layouts/section/job-posting.fr.html
@@ -91,7 +91,7 @@
           <input type="text" class="form-control" id="samples" name="samples" />
         </div> -->
         <gcds-input input-id="samples" label="Exemples de travaux (URL)"
-          hint="Indiquez toute URL pertinente présentant votre travail." size="35" lang="fr">
+          hint="Indiquez toute URL pertinente présentant votre travail." size="100" lang="fr">
         </gcds-input>
 
         <!-- How did you hear about this job-->


### PR DESCRIPTION
# Summary | Résumé

Running into an issue where the URL samples field would only accept full url, changed the type from url to text