### PR TITLE
Update contact us section

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -262,11 +262,7 @@ homepage-used-by-hundred-list-five:
 homepage-used-by-image-alt:
   other: "A person standing in front of an image of earth. Around this person are portraits of people connected by a network of lines."  
 contact-cds:
-  other: "Contact CDS"          
-email-us:
-  other: "You can contact us by emailing"
-stay-in-touch:
-  other: "Stay in touch"
+  other: "Connect with us" 
 newsletter:
   other: "Newsletter"
 linkedin:

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -266,11 +266,7 @@ homepage-used-by-hundred-list-five:
 homepage-used-by-image-alt:
   other: "Une personne debout devant une image de la Terre. Autour d’elle se trouvent des portraits de gens connectés par un réseau de lignes."   
 contact-cds:
-  other: "Contactez le SNC"          
-email-us:
-  other: "Vous pouvez nous contacter par courriel à l’adresse"
-stay-in-touch:
-  other: "Gardons contact"
+  other: "Gardons le contact"          
 newsletter:
   other: "Infolettre"
 linkedin:

--- a/layouts/section/about-us.html
+++ b/layouts/section/about-us.html
@@ -1,32 +1,35 @@
 {{ define "main" }}
  {{ .Content }}
     <section>
-        <div style="background-color: #D7E5F5;">
-            <div class="container" style="padding-top: 2rem;">
+        <div style="padding-bottom:1.75rem;">
+            <div class="container">
                 <div class="row">
                     <div class="col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1 col-xs-12">
                         <h2>{{ i18n "contact-cds"}}</h2>
-                        <p>{{ i18n "email-us" }} <a href="mailto:cds-snc@tbs-sct.gc.ca">cds-snc@tbs-sct.gc.ca</a></p>
+                        <ul class="stay-in-touch">
+                            <li>
+                                <gcds-link href="mailto:cds-snc@tbs-sct.gc.ca">cds-snc@tbs-sct.gc.ca</gcds-link>
+                            </li>
+                            <li>
+                                <gcds-link href="https://linkedin.com/company/{{$.Site.Data.contact.linkedin}}">LinkedIn <gcds-icon
+                                    name="linkedin"
+                                    label="LinkedIn"
+                                    margin-left="100"
+                                  /></gcds-link>
+                            </li>
+                            <li>
+                                <gcds-link href={{ i18n "all-newsletter-past" }}>{{ i18n "newsletter" }} <gcds-icon
+                                    name="newspaper"
+                                    label={{ i18n "newsletter" }}
+                                    margin-left="100"
+                                  /></gcds-link>
+                            </li>
+                        </ul>
                     </div>
                     
                 </div>
                 
                 
-            </div>
-        </div>
-        <div class="container" style="padding-top: 2rem;">
-            <div class="row">
-                <div class="col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1 col-xs-12">
-                    <h2>{{ i18n "stay-in-touch" }}</h2>
-                    <ul class="stay-in-touch">
-                        <li>
-                            <a href={{ i18n "all-newsletter-past" }}>{{ i18n "newsletter" }}</a>
-                        </li>
-                        <li>
-                            <a href="https://linkedin.com/company/{{$.Site.Data.contact.linkedin}}">LinkedIn</a>
-                        </li>
-                    </ul>
-                </div>
             </div>
         </div>
     </section>


### PR DESCRIPTION
# Summary | Résumé
 - merge contact us + keep in touch into one
 - use gcds link and icon component
 - change background of contact us to off-white for better contrast with links

| Before | After |
|--------|-------|
| <img width="1206" alt="image" src="https://github.com/cds-snc/digital-canada-ca-website/assets/6607541/3d6b26ed-29d6-4b6b-90d7-213105cd5255"> |  <img width="1214" alt="image" src="https://github.com/cds-snc/digital-canada-ca-website/assets/6607541/a5fd75ae-bcfc-4455-85d3-4900e06d6645">  |
| <img width="1188" alt="image" src="https://github.com/cds-snc/digital-canada-ca-website/assets/6607541/5fa5210b-47f4-4ff5-9212-d74e231b6dc3"> | <img width="1246" alt="image" src="https://github.com/cds-snc/digital-canada-ca-website/assets/6607541/adc53a76-c0a8-49ff-97f6-7beb37c49bf0"> |
