### PR TITLE
Tiny tweaks to on single blog posts to fix some padding and alignment

### DIFF
--- a/assets/sass/cds/_blog.scss
+++ b/assets/sass/cds/_blog.scss
@@ -190,6 +190,15 @@
   }
 }
 
+.blog-single {
+  padding-top: 4rem;
+
+  .container {
+    // more css shenanigans for grid alignment stuff btwen bootstrap and GCDS
+    padding: 0 30px;
+  }
+}
+
 article.post {
 
   img {


### PR DESCRIPTION
# Summary | Résumé
Some small tweaks in the css to correct the padding and alignment on single blogs.

| Before | After |
|--------|-------|
|  <img width="1192" alt="image" src="https://github.com/cds-snc/digital-canada-ca-website/assets/6607541/b468dbd1-b485-43ef-9ba7-c022a7aa023a">   | <img width="1159" alt="image" src="https://github.com/cds-snc/digital-canada-ca-website/assets/6607541/448faa0e-eafb-4cab-8bd3-7cac0b53e655">  |