### PR TITLE
markdownify blog titles

### DIFF
--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -5,7 +5,7 @@
             {{ with .GetPage "blog" }}
                 <gcds-breadcrumbs-item href={{ .Page.RelPermalink | absLangURL }}>{{ .Page.Title | title }}</gcds-breadcrumbs-item>
             {{ end }}
-            <gcds-breadcrumbs-item href={{ .Page.RelPermalink | absLangURL }}>{{ .Page.Title | title }}</gcds-breadcrumbs-item>
+            <gcds-breadcrumbs-item href={{ .Page.RelPermalink | absLangURL }}>{{ .Page.Title | markdownify }}</gcds-breadcrumbs-item>
         {{ else }}
             <gcds-breadcrumbs-item href={{ .Page.RelPermalink | absLangURL }}>{{ .Page.Title | title }}</gcds-breadcrumbs-item>
         {{ end }}


### PR DESCRIPTION
# Summary | Résumé
Quick fix to make sure ampersands and such in blog titles in the breadcrumbs are correctly rendered

| Before | After |
|--------|-------|
| <img width="1078" alt="image" src="https://github.com/cds-snc/digital-canada-ca-website/assets/6607541/b99eebc6-661c-4261-a6a0-ce0ef6ce621d">  |  <img width="1019" alt="image" src="https://github.com/cds-snc/digital-canada-ca-website/assets/6607541/dbee9ccd-b628-403f-b5c9-21d39d2cc5ff">  |


