### PR TITLE
change footer to full canada.ca footer

### DIFF
--- a/layouts/partials/footer.en.html
+++ b/layouts/partials/footer.en.html
@@ -1,6 +1,6 @@
 <gcds-footer
-  display="compact"
+  display="full"
   contextual-heading="Canadian Digital Service (CDS)"
-  contextual-links='{ "Contact": "mailto:cds-snc@servicecanada.gc.ca", "Jobs": "/jobs/" }'
+  contextual-links='{ "Contact CDS": "mailto:cds-snc@servicecanada.gc.ca", "Jobs at CDS": "/jobs/" }'
   sub-links='{"Terms and Conditions": "/terms/", "Privacy": "/privacy/", "Security" :"/security-notice/", "Visit Canada.ca": "https://www.canada.ca/en.html"}'>
 </gcds-footer>

--- a/layouts/partials/footer.fr.html
+++ b/layouts/partials/footer.fr.html
@@ -1,6 +1,6 @@
 <gcds-footer
-  display="compact"
+  display="full"
   contextual-heading="Service numérique canadien (SNC)"
-  contextual-links='{ "Contact": "mailto:cds-snc@servicecanada.gc.ca", "Emplois": "/emplois/" }'
+  contextual-links='{ "Contactez le SNC": "mailto:cds-snc@servicecanada.gc.ca", "Emplois au SNC": "/emplois/" }'
   sub-links='{"Avis": "/avis/", "Confidentialité": "/confidentialite/", "Sécurité" :"/avis-de-securite/", "Visitez Canada.ca": "https://www.canada.ca/fr.html"}'>
 </gcds-footer>


### PR DESCRIPTION
# Summary | Résumé
Part of the feedback received was the use the full canada.ca footer underneath our contextual one. This PR integrates that request.


| Before | After |
|--------|-------|
|  <img width="1207" alt="image" src="https://github.com/cds-snc/digital-canada-ca-website/assets/6607541/855c7a9d-c4ea-492e-bc7c-32418ad3a1d4">  |  <img width="1213" alt="image" src="https://github.com/cds-snc/digital-canada-ca-website/assets/6607541/3bd5e5c8-91b0-426f-baf1-ee69e147e030">  |