### PR TITLE
updated hugo version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
 			"version": "latest"
 		},
 		"ghcr.io/devcontainers/features/hugo:1": {
-			"version": "0.55.6"
+			"version": "0.124.0"
 		},
 		"terraform": {
 			"version": "1.4.6",

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -25,10 +25,10 @@ jobs:
 
     - name: Install hugo
       run: |
-        wget https://github.com/gohugoio/hugo/releases/download/v0.55.6/hugo_extended_0.55.6_Linux-64bit.tar.gz \
-        && tar -xvf hugo_extended_0.55.6_Linux-64bit.tar.gz hugo \
+        wget https://github.com/gohugoio/hugo/releases/download/v0.124.0/hugo_extended_0.124.0_Linux-64bit.tar.gz \
+        && tar -xvf hugo_extended_0.124.0_Linux-64bit.tar.gz hugo \
         && mv  hugo /usr/local/bin \
-        && rm hugo_extended_0.55.6_Linux-64bit.tar.gz
+        && rm hugo_extended_0.124.0_Linux-64bit.tar.gz
 
     - name: Build english and french sites
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG HUGO_VERSION="0.87.0"
+ARG HUGO_VERSION="0.124.0"
 RUN wget "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz" \
     && tar -xvf hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz hugo \
     && mv  hugo /usr/bin \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG HUGO_VERSION="0.125.0"
+ARG HUGO_VERSION="0.87.0"
 RUN wget "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz" \
     && tar -xvf hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz hugo \
     && mv  hugo /usr/bin \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG HUGO_VERSION="0.55.6"
+ARG HUGO_VERSION="0.125.0"
 RUN wget "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz" \
     && tar -xvf hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz hugo \
     && mv  hugo /usr/bin \


### PR DESCRIPTION
# Summary | Résumé

We're currently running version 0.55.6, updating to the latest v0.124.0. In the past, updates to the version have apparently led to breaking change but from testing, that doesn't seem to be the case any more. 