### PR TITLE
Slight padding and alignment tweaks for job posting section

### DIFF
--- a/assets/sass/cds/_pages.scss
+++ b/assets/sass/cds/_pages.scss
@@ -142,6 +142,11 @@
   h3:first-child {
     margin-top: 0;
   }
+
+  .current-openings {
+    padding-left: 15px;
+    padding-bottom: 35px;
+  }
 }
 
 ::-webkit-file-upload-button {

--- a/layouts/section/jobs.en.html
+++ b/layouts/section/jobs.en.html
@@ -26,7 +26,7 @@
                 <div>
                     {{ if gt (len (where .Pages ".Params.archived" "==" false)) 0 }}
 
-                    <div class="row">
+                    <div class="row current-openings">
 
                         <h2>Current openings</h2>
                         {{ range $p := (where .Pages ".Params.archived" "==" false) }}


### PR DESCRIPTION
Noticed some spacing/alignment issues job posts on the job posting list, so I created a new class for the specific row that needed to be realigned and made a quick CSS fix:

From this:
![image](https://github.com/cds-snc/digital-canada-ca-website/assets/39972942/75ce4203-9f04-4a41-be23-482e7318b332)

To this: 
![image](https://github.com/cds-snc/digital-canada-ca-website/assets/39972942/1a224e3d-0189-45ca-85b0-4cc139c62067)
