### PR TITLE
ga4 linkedin test

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -306,4 +306,6 @@ meta-identifier:
 meta-subject:
   other: "GC digital, Canadian Digital Service, digital services, digital government, platform, open source, accessibility, cloud, API, agile, testing"        
 homepage:
-  other: "Home page"  
+  other: "Home page"
+ga4-linkedin:
+  other: "EN_LinkedIn"    

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -310,4 +310,6 @@ meta-identifier:
 meta-subject:
   other: "GC numérique, Service numérique canadien, services numériques, numérique du gouvernement, plateform, source ouverte; accessibilité, nuage, API, egile, essais,"                                 
 homepage:
-  other: "Page d’accueil"  
+  other: "Page d’accueil"
+ga4-linkedin:
+  other: "FR_LinkedIn"        

--- a/layouts/section/about-us.html
+++ b/layouts/section/about-us.html
@@ -15,6 +15,7 @@
                                     name="linkedin"
                                     label="LinkedIn"
                                     margin-left="100"
+                                    id={{ i18n "ga4-linkedin" }}
                                   /></gcds-link>
                             </li>
                             <li>


### PR DESCRIPTION
# Summary | Résumé

Testing GA4 by adding id to linkedin element on the homepage