### PR TITLE
Updating main header text on English and French homepage

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -11,7 +11,7 @@ aliases: [/products/]
         <div class="row">
             <div class="col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1 col-xs-12">
                 <div class="header">
-                    <div style="float: left;">
+                    <div style="float: left; max-width:620px;">
                         <h1>Digital products for the Government of Canada</h1>
                         <p>built by <a href="/about/">the Canadian Digital Service</a> to improve service experiences in the Government of Canada.</p>
                         <p><a href="https://digital.canada.ca/about/#our-vision">Read our Strategic Vision to learn more about our work.</a></p>

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -13,8 +13,8 @@ aliases: [/products/]
                 <div class="header">
                     <div style="float: left;">
                         <h1>Digital products for the Government of Canada</h1>
-                        <p>built by <a href="/about/">the Canadian Digital Service</a>
-                        </p>
+                        <p>built by <a href="/about/">the Canadian Digital Service</a> to improve service experiences in the Government of Canada.</p>
+                        <p><a href="https://digital.canada.ca/about/#our-vision">Read our Strategic Vision to learn more about our work.</a></p>
                     </div>
                     <div style="float: left;">
                         <img src="/img/cds/homepage-header.svg" alt="A group of people building a web page together." />

--- a/content/en/about-us.html
+++ b/content/en/about-us.html
@@ -32,7 +32,7 @@ aliases: [/meet-the-team/, /coaching-and-advice/]
                 </ul>
             </div>
             <div>
-                <h2>Our vision</h2>
+                <h2 id="our-vision">Our vision</h2>
                 <ul>
                     <li><a href="/reports/strategy-2024.pdf" target="_blank">2024-2027 Strategy</a></li>
                     <li><a href="/reports/tactical-plan-2024.pdf" target="_blank">2024-2025 Tactical plan</a></li>

--- a/content/fr/_index.html
+++ b/content/fr/_index.html
@@ -11,7 +11,7 @@ aliases: [/produits/]
         <div class="row">
             <div class="col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1 col-xs-12">
                 <div class="header">
-                    <div style="float: left;">
+                    <div style="float: left; max-width:620px;">
                         <h1>Des produits numériques pour le gouvernement du Canada</h1>
                         <p>créés par le <a href="/a-propos/">Service numérique canadien</a> pour améliorer les expériences de service offertes par le gouvernement du Canada.</p>
                         <p><a href="https://numerique.canada.ca/a-propos/#notre-vision">Découvrez notre vision stratégique pour en savoir plus sur notre travail.</a></p>

--- a/content/fr/_index.html
+++ b/content/fr/_index.html
@@ -13,11 +13,11 @@ aliases: [/produits/]
                 <div class="header">
                     <div style="float: left;">
                         <h1>Des produits numériques pour le gouvernement du Canada</h1>
-                        <p>créés par le <a href="/a-propos/">Service numérique canadien</a>
-                        </p>
+                        <p>créés par le <a href="/a-propos/">Service numérique canadien</a> pour améliorer les expériences de service offertes par le gouvernement du Canada.</p>
+                        <p><a href="https://numerique.canada.ca/a-propos/#notre-vision">Découvrez notre vision stratégique pour en savoir plus sur notre travail.</a></p>
                     </div>
                     <div style="float: left;">
-                        <img src="/img/cds/homepage-header.svg" alt="A group of people building a web page together." />
+                        <img src="/img/cds/homepage-header.svg" alt="A group of people building a web page together."/>
                     </div>
                 </div>
             </div>

--- a/content/fr/about-us.html
+++ b/content/fr/about-us.html
@@ -28,7 +28,7 @@ aliases: [/recontrez-lequipe/, /encadrement-et-conseil/]
                 </ul>
             </div>
             <div>
-                <h2>Notre vision</h2>
+                <h2 id="notre-vision">Notre vision</h2>
                 <ul>
                     <li><a href="/rapports/strategie-2024.pdf" target="_blank">Stratégie 2024-2027</a></li>
                     <li><a href="/rapports/plan-tactique-2024.pdf" target="_blank">Plan tactique 2024-2025</a></li>


### PR DESCRIPTION
This update includes changes to the following text:

**English Homepage:**
<img width="1285" alt="Screenshot 2024-07-31 at 9 25 15 AM" src="https://github.com/user-attachments/assets/865acd9c-b62e-4217-832d-5548bde0af51">

**French Homepage:**
<img width="1293" alt="Screenshot 2024-07-31 at 9 28 13 AM" src="https://github.com/user-attachments/assets/c7b9c6c4-e604-478e-af4f-092d0f5e9179">

The link "Read our Strategic Vision to learn more about our work" leads to the a specific section with the IDs #our-vision and #notre-vision on the [English](https://digital.canada.ca/) and [French](https://numerique.canada.ca/a-propos/) About pages. 