### PR TITLE
feat: Move Lever api endpoint to a env variable

### DIFF
--- a/assets/js/cds-app.js
+++ b/assets/js/cds-app.js
@@ -1,3 +1,6 @@
+import * as params from '@params';
+const endpoint = params.lever_api_endpoint;
+
 Object.defineProperty(HTMLMediaElement.prototype, "playing", {
   get: function () {
     return !!(
@@ -56,8 +59,6 @@ $(document).ready(function () {
 
       var formData = new FormData($("#contactForm")[0]);
       var pageLanguage = $("html").attr("lang");
-      var endpoint =
-        "https://944yirpts7.execute-api.ca-central-1.amazonaws.com/Production/lever";
 
       $.ajax({
         type: "POST",

--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -1,3 +1,5 @@
+params:
+  lever_api_endpoint: https://944yirpts7.execute-api.ca-central-1.amazonaws.com/Production/lever
 DefaultContentLanguage: en
 defaultContentLanguageInSubdir: true
 sitemap:

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,6 +2,7 @@
 <html class="no-js" lang="{{ (string ( $.Site.Language) ) }}" dir="ltr">
 {{ $pageTitle := i18n .Params.title }}
 {{ $titleKey := .Params.title }}
+{{ $js := resources.Get "js/cds-app.js" | js.Build (dict "params" .Site.Params ) }}
 
 <head>
   {{ partial "analytics.html" }}
@@ -179,7 +180,7 @@
       crossorigin="anonymous"></script>
     <script src="/lib-cds/gcweb-dist/wet-boew/js/wet-boew.min.js"></script>
     <script src="/lib-cds/gcweb-dist/GCWeb/js/theme.min.js"></script>
-    <script type="text/javascript" src="/js/cds-app.js"></script>
+    <script type="text/javascript" src="{{ $js.RelPermalink }}"></script>
     <script type="text/javascript" src="/js/blog.js"></script>
     <script src="/js/lazyload.js" async=""></script>
     


### PR DESCRIPTION
## Summary | Résumé

Moved the Lever API endpoint to an environment variable (LEVER_API_ENDPOINT) to enhance flexibility and security. This change allows the endpoint to be updated without modifying the codebase.

---

Déplacement de l’endpoint de l’API Lever vers une variable d’environnement (LEVER_API_ENDPOINT) pour améliorer la flexibilité et la sécurité. Cette modification permet de mettre à jour l’endpoint sans modifier le code.

## Test Instructions | Instructions pour tester la modification

1. Set the LEVER_API_ENDPOINT environment variable in the env_vars.hcl file to the desired endpoint.
2. Run the application and verify that all API requests are using the new environment variable.
3. Check that the application functions correctly and that no hardcoded endpoints are being used.
4. Test the application across different environments (e.g., development, staging, production) to ensure the environment variable is correctly set and utilized.

---
1. Définissez la variable d’environnement LEVER_API_ENDPOINT dans le fichier env_vars.hcl à l’endpoint souhaité.
2. Exécutez l’application et vérifiez que toutes les requêtes API utilisent la nouvelle variable d’environnement.
3. Vérifiez que l’application fonctionne correctement et qu’aucun endpoint codé sans varibale n’est utilisé.
4. Testez l’application dans différents environnements (développement, pré-production, production) pour vous assurer que la variable d’environnement est correctement définie et utilisée.