### PR TITLE
Update a couple links and typos on job posting

### DIFF
--- a/content/en/jobs/positions/localization-specialist-—-communications-and-marketing-team--e98f28b4-182b-436a-ad34-13a08a279ab7.md
+++ b/content/en/jobs/positions/localization-specialist-—-communications-and-marketing-team--e98f28b4-182b-436a-ad34-13a08a279ab7.md
@@ -3,7 +3,7 @@ layout: job-posting
 type: section
 title: 'Localization Specialist — Communications and Marketing Team'
 description: >-
-  This role is classified as an IT-03 in the Computer Systems Group (CS), bilingual imperative (CCC).
+  This role is classified as an IT-03 in the Information Technology (IT), bilingual imperative (CCC).
 linkHidden: false
 translationKey: localization-specialist-2024
 leverId: e98f28b4-182b-436a-ad34-13a08a279ab7
@@ -21,7 +21,7 @@ The Communications and Marketing team engages with CDS audiences and shapes the 
 
 ### **The Canadian Digital Service is hiring one Localization Specialist!**
 
-This role is classified as an IT-03 in the [Computer Systems Group (CS)](https://www.tbs-sct.canada.ca/agreements-conventions/view-visualiser-eng.aspx?id=1#toc27633227634), bilingual imperative (CCC). 
+This role is classified as an IT-03 in the [Information Technology (IT)](https://www.tbs-sct.canada.ca/agreements-conventions/view-visualiser-eng.aspx?id=31), bilingual imperative (CCC). 
 
 We welcome applications for various tenures, such as indeterminate, deployment, acting, assignment, secondment, and specified period.  If you are passionate about policy and looking to join a dynamic team, we encourage you to apply!
 
@@ -38,7 +38,7 @@ We welcome applications for various tenures, such as indeterminate, deployment, 
 - Demonstrated expertise in creating cross-cultural content.
 - Proficiency in terminology management and maintaining translation memories.
 - Proven track record in project management within digital government contexts.
-- Familiarity with a range of platforms including Phrase GitHub, Figma, and Trello, or equivalents.
+- Familiarity with a range of platforms including Phrase, GitHub, Figma, and Trello, or equivalents.
 - Ability to work with multidisciplinary agile delivery teams.
 - Ability to contribute to research initiatives on a project.
 

--- a/content/fr/jobs/positions/spécialiste-de-la-localisation-—-équipe-des-communications-et-du-marketing---e98f28b4-182b-436a-ad34-13a08a279ab7.md
+++ b/content/fr/jobs/positions/spécialiste-de-la-localisation-—-équipe-des-communications-et-du-marketing---e98f28b4-182b-436a-ad34-13a08a279ab7.md
@@ -3,7 +3,7 @@ layout: job-posting
 type: section
 title: 'Spécialiste de la localisation — Équipe des Communications et du Marketing '
 description: >-
-  Ce rôle est classé au niveau IT-03 dans le groupe du groupe Systèmes d’ordinateurs (CS) et le profil linguistique est bilingue à nomination impérative (CCC). 
+  Ce rôle est classé au niveau IT-03 dans le groupe du groupe Technologies de l’information (IT) et le profil linguistique est bilingue à nomination impérative (CCC). 
 linkHidden: false
 translationKey: localization-specialist-2024
 leverId: e98f28b4-182b-436a-ad34-13a08a279ab7
@@ -21,14 +21,14 @@ L’équipe de communications et marketing interagit avec le public cible du SNC
 
 ### **Le Service numérique canadien est à la recherche d'un·e spécialiste de la localisation!**
 
-Ce rôle est classé au niveau IT-03 dans le groupe [Systèmes d’ordinateurs (CS)](https://www.tbs-sct.canada.ca/agreements-conventions/view-visualiser-fra.aspx?id=1) et le profil linguistique est bilingue à nomination impérative (CCC). 
+Ce rôle est classé au niveau IT-03 dans le groupe [Technologies de l’information (IT)](https://www.tbs-sct.canada.ca/agreements-conventions/view-visualiser-fra.aspx?id=31) et le profil linguistique est bilingue à nomination impérative (CCC). 
 
 Nous acceptons les candidatures de différentes catégories, telles que celles de durée indéterminée ou déterminée, de mutation, d’intérim, d’affectation ou de détachement.  Si le domaine numérique vous passionne  et que vous souhaitez vous joindre à une équipe dynamique, nous vous invitons à postuler!
 
 **Principales tâches et responsabilités :**
 - Gérer les composants multilingues des produits numériques, tels que les sites web, les applications mobiles et les plateformes logicielles.
 - Gérer les bases terminologies et assurer l'intégrité des terminologies dans divers domaines.
-- Éditer, réviser et effectuer des révisions comparatives de textes dans les deux langues officielles pour respecter les normes de - qualité les plus élevées.
+- Éditer, réviser et effectuer des révisions comparatives de textes dans les deux langues officielles pour respecter les normes de qualité les plus élevées.
 - Diriger les efforts de gestion de projet en collaborant avec des développeurs, des designers de contenu et des chefs de produit pour stimuler les stratégies de sensibilisation et de croissance.
 - Utiliser des outils numériques tels que Phrase, GitHub, Figma, Trello et d'autres pour optimiser les flux de travail de gestion de projet.
 


### PR DESCRIPTION
# Summary | Résumé
Specifically for the IT-03 localization specialist.

The changes are as follows:
- update the links to the new collective agreements
- update the title of the links in the text and the meta description (from CS to IT)
- remove an unnecessary hyphen in the french text.

# Testing
- assure all links are correct :)




