### PR TITLE
Publish Evergreen job posting on Jobs page

### DIFF
--- a/content/en/jobs/positions/share-your-resume--77d1c499-8722-41ad-9985-e163d76b0e39.md
+++ b/content/en/jobs/positions/share-your-resume--77d1c499-8722-41ad-9985-e163d76b0e39.md
@@ -1,0 +1,19 @@
+---
+layout: job-posting
+type: section
+title: 'Be considered for future opportunities'
+description: >-
+ If there isn't a current job opening that is the right fit for you, you can apply to be considered for future opportunities as they come up.
+archived: true
+translationKey: evergreen-job-posting
+leverId: 77d1c499-8722-41ad-9985-e163d76b0e39
+---
+
+
+## By filling out this application:
+
+
+**You’re indicating interest to work at CDS, generally.** You’re not applying for a specific job. As positions become available, applicants who meet the criteria may be contacted for an introductory call.
+
+
+**You can still apply to other job postings.** We invite you to check our [jobs](/jobs/) page regularly!

--- a/content/fr/jobs/positions/envoyer-votre-c.v.--77d1c499-8722-41ad-9985-e163d76b0e39.md
+++ b/content/fr/jobs/positions/envoyer-votre-c.v.--77d1c499-8722-41ad-9985-e163d76b0e39.md
@@ -1,0 +1,17 @@
+---
+layout: job-posting
+type: section
+title: 'Laissez-nous votre CV pour d’éventuels futurs postes'
+description: >-
+ Si aucun des postes ne vous convient actuellement, vous pouvez soumettre votre candidature afin qu’elle soit prise en compte pour de futures offres d’emploi.
+archived: true
+translationKey: evergreen-job-posting
+leverId: 77d1c499-8722-41ad-9985-e163d76b0e39
+---
+## En remplissant ce formulaire de candidature :
+
+
+**Vous manifestez votre intérêt général pour un emploi au sein du SNC.** Vous ne postulez à aucun poste en particulier. Lorsque nous aurons des postes disponibles, il se pourrait que nous contactions les personnes correspondant au profil concerné pour un premier appel.
+
+
+**Cela ne vous empêche pas de postuler à d’autres offres d’emploi.** Nous vous encourageons à consulter régulièrement la page « [Emplois](/emplois/) »!


### PR DESCRIPTION
Bringing back the evergreen job posting ("Be considered for future opportunities") link to the [Jobs at CDS](https://digital.canada.ca/jobs/) page. 

_English:_
<img width="777" alt="Screenshot 2024-11-06 at 9 55 01 AM" src="https://github.com/user-attachments/assets/d9c404f1-633f-49e2-8a72-4a1f980bbe32">

**_French:_**
<img width="794" alt="Screenshot 2024-11-06 at 9 55 57 AM" src="https://github.com/user-attachments/assets/7a1d66f9-a4a7-4ca5-9183-a7c32c4dd0d2">
