### PR TITLE
fix: add aliases for blog posts in English and French

### DIFF
--- a/content/en/blog/posts/measuring-progress:-a-product-maturity-model-for-digital-government.md
+++ b/content/en/blog/posts/measuring-progress:-a-product-maturity-model-for-digital-government.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - "/2024/11/04/measuring-progress-a-product-maturity-model-for-digital-government//"
 layout: blog
 title: 'Measuring progress: A product maturity model for digital government'
 description: >-

--- a/content/fr/blog/posts/mesurer-le-progrès :-un-modèle-de-maturité-pour-les-produits-du-gouvernement-numérique..md
+++ b/content/fr/blog/posts/mesurer-le-progrès :-un-modèle-de-maturité-pour-les-produits-du-gouvernement-numérique..md
@@ -1,4 +1,6 @@
 ---
+aliases:
+  - /2024/11/04/mesurer-le-progrès-un-modèle-de-maturité-pour-les-produits-du-gouvernement-numérique.
 layout: blog
 title: 'Mesurer le progrès : un modèle de maturité pour les produits du gouvernement numérique.'
 description: >-


### PR DESCRIPTION
## Summary | Résumé

Added aliases to Hugo blog posts to ensure proper redirection from old URLs to the new ones. This change resolves broken links and improves overall user navigation.

---

Ajout d’alias aux articles de blogue Hugo pour assurer la redirection correcte des anciennes URL vers les nouvelles. Cette modification corrige les liens brisés et améliore la navigation des utilisateurs.

---

## Test instructions | Instructions pour tester la modification

1. Pull the branch and run the site locally using hugo server.
2. Attempt to access blog posts using the old URLs listed in the associated issue.
3. Confirm that the old URLs correctly redirect to the updated URLs without error.
4. Verify that no new errors appear in the browser’s console or Hugo logs during testing.

---

1. Récupérez la branche et exécutez le site en local avec la commande hugo server.
2. Essayez d’accéder aux articles de blogue en utilisant les anciennes URL répertoriées dans le problème associé.
3. Confirmez que les anciennes URL redirigent correctement vers les nouvelles sans erreur.
4. Vérifiez qu’aucune nouvelle erreur n’apparaît dans la console du navigateur ou les journaux de Hugo pendant les tests.