### PR TITLE
Update to recruitment inbox: form submission error message

### DIFF
--- a/content/en/form-submission/error.html
+++ b/content/en/form-submission/error.html
@@ -10,6 +10,6 @@ translationKey: formError
 <div>
     <p>Something went wrong. Please try again in 30 minutes. </p>
     <p>If you are still seeing this message, you can email us at <a
-            href="mailto:cds-snc@servicecanada.gc.ca">cds-snc@servicecanada.gc.ca</a>.
+            href="mailto:cds.recruitment-recrutement.snc@servicecanada.gc.ca ">cds.recruitment-recrutement.snc@servicecanada.gc.ca</a>.
     </p>
 </div>

--- a/content/fr/form-submission/error.html
+++ b/content/fr/form-submission/error.html
@@ -10,6 +10,6 @@ translationKey: formError
 <div>
     <p>Une erreur s’est produite. Veuillez réessayer dans 30 minutes. </p>
     <p>Si ce message s’affiche à nouveau, vous pouvez nous contacter par courriel à l’adresse <a
-            href="mailto:cds-snc@servicecanada.gc.ca">cds-snc@servicecanada.gc.ca</a>.
+            href="mailto:cds.recruitment-recrutement.snc@servicecanada.gc.ca ">cds.recruitment-recrutement.snc@servicecanada.gc.ca</a>.
     </p>
 </div>


### PR DESCRIPTION
The Talent Team has set up a specific inbox to support recruitment needs, including job application errors with the submission form. This PR updates English and French error messages to reflect the new inbox ([CDS.RECRUITMENT-RECRUTEMENT.SNC@servicecanada.gc.ca](mailto:CDS.RECRUITMENT-RECRUTEMENT.SNC@servicecanada.gc.ca)).

Previous email: CDS-SNC@servicecanada.gc.ca 

**_Preview links to test:_** 
- https://xkzpvhc5t7j5dm5cxjr3qc55wu0bfbxq.lambda-url.ca-central-1.on.aws/error
- https://ula7qxf6qgfaqbdkdfgwwgwvmu0megbv.lambda-url.ca-central-1.on.aws/erreur