### PR TITLE
Put header logo back in place

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,7 +5,7 @@
     {{ end }}
 
     <gcds-top-nav label="Top navigation" alignment="right" slot="menu">
-        <gcds-nav-link href="{{ .Site.BaseURL | absLangURL }}" lang="{{ .Language }}" class="cds-logo {{ .Site.Params.Lang }}" slot="home" slot="left" aria-label='{{ i18n "aria-cds-website" }}' id="cds-logo" ></gcds-nav-link>
+        <gcds-nav-link href="{{ .Site.BaseURL | absLangURL }}" lang="{{ .Language }}" class="cds-logo {{ .Site.Language.Lang }}" slot="home" slot="left" aria-label='{{ i18n "aria-cds-website" }}' id="cds-logo" ></gcds-nav-link>
         {{ $title := .Params.title }}
         {{ range $menu := .Site.Menus.main }}
         <gcds-nav-link href="{{ .URL | relLangURL }}" data-gc-analytics-navigation="header:Canadian Digital Service: {{ .Name }}" class="{{ if eq $title .Identifier }} menu-underline{{ end }}">{{ .Name }}</gcds-nav-link>


### PR DESCRIPTION
# Summary | Résumé
Logo in the header went missing [in this old PR](https://github.com/cds-snc/digital-canada-ca-website/commit/9010e3aa5b0a03db843fa9ca5287ff7f4054db0a#diff-42986cf40ad96f5b7ca39d9b71ba6a9f252656de24cfe82100892ff0f4400f90R7),  `Site.Params.Lang` won't set the language class properly, but `Site.Language.Lang` will.

| English | French |
|--------|-------|
|   <img width="1226" alt="image" src="https://github.com/user-attachments/assets/5ad2f801-9fe6-4722-849d-6062816fd547" />   |   <img width="1214" alt="image" src="https://github.com/user-attachments/assets/1eacbfc8-c63f-459a-9d32-3f30e56f486c" />   |



