### PR TITLE
Add periods at the end of product card descriptions on Homepage

### DIFF
--- a/content/en/our-products/canada-ca-content-style-guide.md
+++ b/content/en/our-products/canada-ca-content-style-guide.md
@@ -1,5 +1,5 @@
 ---
-description: Write accessible and clear content
+description: Write accessible and clear content.
 link: 'https://design.canada.ca/style-guide/'
 Section: our-products
 title: 'Canada.ca Content Style Guide'

--- a/content/en/our-products/design-for-canada-ca.md
+++ b/content/en/our-products/design-for-canada-ca.md
@@ -1,5 +1,5 @@
 ---
-description: Canada.ca specifications, IA and continuous web improvement
+description: Canada.ca specifications, IA and continuous web improvement.
 link: 'https://design.canada.ca/'
 Section: our-products
 title: 'Design for Canada.ca'

--- a/content/en/our-products/gc-design-systems.md
+++ b/content/en/our-products/gc-design-systems.md
@@ -1,6 +1,6 @@
 ---
 title: 'GC Design System'
-description: Design consistent web experiences
+description: Design consistent web experiences.
 image: '/img/cds/gc-design-systems.svg'
 imageAlt: 'Screenshot of GC Design System'
 link: 'https://design-system.alpha.canada.ca/en/'

--- a/content/en/our-products/gc-forms.md
+++ b/content/en/our-products/gc-forms.md
@@ -1,6 +1,6 @@
 ---
 title: 'GC Forms'
-description: Create accessible online forms
+description: Create accessible online forms.
 image: '/img/cds/en-gc-forms.svg'
 imageAlt: 'Screenshot of GC Forms'
 link: 'https://articles.alpha.canada.ca/forms-formulaires/'

--- a/content/en/our-products/gc-issue-and-verify.md
+++ b/content/en/our-products/gc-issue-and-verify.md
@@ -1,6 +1,6 @@
 ---
 title: 'GC Issue and Verify'
-description: Issue and verify digital versions of credentials (licenses, permits, etc.)
+description: Issue and verify digital versions of credentials (licenses, permits, etc).
 link: 'https://www.canada.ca/en/government/system/digital-government/digital-government-innovations/digital-credentials.html'
 weight: 10
 ---

--- a/content/en/our-products/gc-notify.md
+++ b/content/en/our-products/gc-notify.md
@@ -1,6 +1,6 @@
 ---
 title: 'GC Notify'
-description: Send automated email and text notifications
+description: Send automated email and text notifications.
 image: '/img/cds/en-gc-notify.svg'
 imageAlt: 'Screenshot of GC Notify'
 link: 'https://notification.canada.ca/'

--- a/content/en/our-products/gc-sign-in.md
+++ b/content/en/our-products/gc-sign-in.md
@@ -1,6 +1,6 @@
 ---
 title: 'GC Sign in'
-description: Let your clients sign in to online services easily and securely
+description: Let your clients sign in to online services easily and securely.
 link: 'https://www.canada.ca/en/government/system/digital-government/digital-government-innovations/digital-credentials.html'
 weight: 9
 ---

--- a/content/en/our-products/gc-task-success-survey.md
+++ b/content/en/our-products/gc-task-success-survey.md
@@ -1,6 +1,6 @@
 ---
 title: 'GC Task Success Survey'
-description: Collect feedback from users on a multi-page task
+description: Collect feedback from users on a multi-page task.
 link: 'https://design.canada.ca/survey/'
 weight: 7
 ---

--- a/content/en/our-products/page-feedback-tool.md
+++ b/content/en/our-products/page-feedback-tool.md
@@ -1,6 +1,6 @@
 ---
 title: 'Page Feedback Tool'
-description: Collect feedback from users on a specific webpage
+description: Collect feedback from users on a specific webpage.
 link: 'https://design.canada.ca/feedback/index.html'
 weight: 8
 ---

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -34,7 +34,7 @@
 
 {{ define "index" }}
 <!-- Illustrations by StorySet - https://storyset.com/` -->
-<section class="partnership-products">
+<section class="partnership-products" id="products-section">
   <h2 class="wb-inv">{{ i18n "homepage-section-title" }}</h2>
   {{ $home_products := where .Site.Pages "Section" "==" "our-products" }}
   


### PR DESCRIPTION
Adding periods at the end of every product card description on the [English Homepage](https://digital.canada.ca/). 

**Before:**
<img width="1015" alt="Screenshot 2025-02-20 at 5 49 17 PM" src="https://github.com/user-attachments/assets/ae3461c9-7483-45ce-b81d-e2fbf7c70cb7" />

**After:** 
<img width="990" alt="Screenshot 2025-02-20 at 5 52 47 PM" src="https://github.com/user-attachments/assets/d920f907-a0e2-4cda-b332-5696aa3076cb" />

