### PR TITLE
Fix/security page updates

### DIFF
--- a/content/en/security-notice.html
+++ b/content/en/security-notice.html
@@ -39,6 +39,7 @@ aliases: [/legal/security-notice/, /avis-de-securite/, /transparence/avis-de-sec
                     <li>*.numerique.canada.ca</li>
                     <li>*.notification.canada.ca</li>
                     <li>*.cdssandbox.xyz</li>
+                    <li>design-system.alpha.canada.ca</li>
                     <li>articles.alpha.canada.ca</li>
                     <li>forms-formulaires.alpha.canada.ca</li>
                     <li>list-manager.alpha.canada.ca</li>
@@ -62,7 +63,7 @@ aliases: [/legal/security-notice/, /avis-de-securite/, /transparence/avis-de-sec
                         vulnerabilities.</li>
                 </ul>
                 <gcds-button type="link"
-                    href="https://forms-formulaires.alpha.canada.ca/en/id/clo5w00r900neym647s3t8nmp">
+                    href="https://forms-formulaires.alpha.canada.ca/en/id/clo5w00o700naym64tg6qrrqf">
                     Report a vulnerability <gcds-icon name="fa-solid fa-chevron-right"></gcds-icon>
                 </gcds-button>
             </div>
@@ -124,7 +125,7 @@ aliases: [/legal/security-notice/, /avis-de-securite/, /transparence/avis-de-sec
                     </li>
                 </ul>
             </div>
-            <gcds-button type="link" href="https://forms-formulaires.alpha.canada.ca/en/id/clo5w00r900neym647s3t8nmp">
+            <gcds-button type="link" href="https://forms-formulaires.alpha.canada.ca/en/id/clo5w00o700naym64tg6qrrqf">
                 Report a vulnerability <gcds-icon name="fa-solid fa-chevron-right"></gcds-icon>
             </gcds-button>
 

--- a/content/fr/security-notice.html
+++ b/content/fr/security-notice.html
@@ -33,6 +33,7 @@ aliases: [/transparence/avis-de-securite/, /security-notice/]
                     <li>*.numerique.canada.ca</li>
                     <li>*.notification.canada.ca</li>
                     <li>*.cdssandbox.xyz</li>
+                    <li>systeme-design.alpha.canada.ca</li>
                     <li>articles.alpha.canada.ca</li>
                     <li>forms-formulaires.alpha.canada.ca</li>
                     <li>list-manager.alpha.canada.ca</li>
@@ -51,7 +52,7 @@ aliases: [/transparence/avis-de-securite/, /security-notice/]
                     <li>ne donnera lieu à aucune rémunération pour vos recherches et tests réalisés en vue de divulguer des vulnérabilités.</li>
                 </ul>
                 <gcds-button type="link"
-                    href="https://forms-formulaires.alpha.canada.ca/fr/id/clo5w00r900neym647s3t8nmp">
+                    href="https://forms-formulaires.alpha.canada.ca/fr/id/clo5w00o700naym64tg6qrrqf">
                     Signaler une vulnérabilité <gcds-icon
                         name="fa-solid fa-chevron-right"></gcds-icon>
                 </gcds-button>
@@ -109,7 +110,7 @@ aliases: [/transparence/avis-de-securite/, /security-notice/]
                     <li>Nous traiterons votre rapport conformément à la Loi sur l’accès à l’information et à la Loi sur la protection des renseignements personnels.</li>
                 </ul>
                 <gcds-button type="link"
-                href="https://forms-formulaires.alpha.canada.ca/fr/id/clo5w00r900neym647s3t8nmp">
+                href="https://forms-formulaires.alpha.canada.ca/fr/id/clo5w00o700naym64tg6qrrqf">
                 Signaler une vulnérabilité <gcds-icon
                     name="fa-solid fa-chevron-right"></gcds-icon>
             </gcds-button>


### PR DESCRIPTION
Update content on security page and point to new form that lists Design System, removes Learning Resources, and includes new content for submissions