### PR TITLE
Remove Lever section in Privacy notice

### DIFF
--- a/content/en/privacy.html
+++ b/content/en/privacy.html
@@ -51,17 +51,6 @@ aliases: [/legal/privacy/, /legal/privacy-notice/, /confidentialite/, /transpare
 					href="https://www.canada.ca/en/treasury-board-secretariat/services/access-information-privacy/access-information/information-about-programs-information-holdings/standard-personal-information-banks.html#psu938">Outreach
 					Activities, PSU 938</a>.</p>
 
-			<h3>Applying for a job at CDS</h3>
-			<p>We use Lever Hire, a third-party application, to collect the information submitted in CDS job
-				applications. Applications are subject to <a href="https://www.lever.co/terms-of-service/2">Lever Hire's
-					Terms of Service</a>. When you apply, you provide your name, contact information, and past work
-				experiences to us and Lever Hire.</p>
-			<p>You can read about how we handle this specific information in <a
-					href="https://www.canada.ca/en/treasury-board-secretariat/services/access-information-privacy/access-information/information-about-programs-information-holdings/standard-personal-information-banks.html#psu911">Applications
-					for Employment, PSU 911</a> and <a
-					href="https://www.canada.ca/en/treasury-board-secretariat/services/access-information-privacy/access-information/information-about-programs-information-holdings/standard-personal-information-banks.html#pse902">Staffing,
-					PSU 902</a>.</p>
-
 			<h2>We protect your privacy</h2>
 			<p>As part of Employment and Social Development Canada, we have the permission to collect and store personal
 				information from the Department of Employment and Social Development Act Section 5.1. The type of

--- a/content/fr/privacy.html
+++ b/content/fr/privacy.html
@@ -57,19 +57,6 @@ aliases: [/transparence/confidentialite/, /privacy/]
                     href="https://www.canada.ca/fr/secretariat-conseil-tresor/services/acces-information-protection-reseignements-personnels/acces-information/renseignements-programmes-fonds-renseignements/fichiers-renseignements-personnels-ordinaires.html#pou938">Activités
                     de sensibilisation, POU 938</a>.</p>
 
-            <h3>Soumission d’une demande d’emploi au SNC</h3>
-            <p>Nous utilisons Lever Hire, une application d’une tierce partie, pour collecter les renseignements soumis
-                sur le portail des offres d’emploi du SNC. Les demandes d’emploi sont assujetties aux <a
-                    href="https://www.lever.co/terms-of-service/2">conditions
-                    d’utilisation de Lever Hire</a>. Lorsque vous soumettez une demande d’emploi, vous fournissez votre
-                nom, vos
-                coordonnées et votre expérience de travail antérieure à Lever Hire et à nous-mêmes.</p>
-            <p>Vous pouvez vous informer sur la façon dont nous gérons ce type de renseignements sur <a
-                    href="https://www.canada.ca/fr/secretariat-conseil-tresor/services/acces-information-protection-reseignements-personnels/acces-information/renseignements-programmes-fonds-renseignements/fichiers-renseignements-personnels-ordinaires.html#pou911">Demandes
-                    d’emploi, POU 911</a> et <a
-                    href="https://www.canada.ca/fr/secretariat-conseil-tresor/services/acces-information-protection-reseignements-personnels/acces-information/renseignements-programmes-fonds-renseignements/fichiers-renseignements-personnels-ordinaires.html#poe9021">Dotation,
-                    POE 902</a></p>
-
             <h2>Nous veillons à votre confidentialité</h2>
 
             <p>Le SNC faisant partie d’Emploi et développement social Canada (EDSC), nous avons l’autorisation de


### PR DESCRIPTION
This PR removes the Lever section in our [Privacy notice page](https://digital.canada.ca/privacy/) (EN + FR). 

Before: 
<img width="1089" alt="Screenshot 2025-03-20 at 8 04 37 AM" src="https://github.com/user-attachments/assets/58136385-48ec-40a2-a4b1-550bf69b633b" />

After:
<img width="1103" alt="Screenshot 2025-03-20 at 8 04 52 AM" src="https://github.com/user-attachments/assets/175079c6-c7fa-4e1a-8f75-97838732b177" />
