### PR TITLE
Edit feedback copy and add to side nav

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -319,8 +319,12 @@ view-tags:
 
 toolkit-credits:
   other: "illustration via storyset"
+toolkit-feedback-title: 
+  other: "Help us improve"
 toolkit-feedback-text:
-  other: "Do you think this page is missing something important? Or maybe you have a suggestion to make it better? We’d love to hear from you! Share your feedback with us at: [cds-snc@servicecanada.gc.ca](mailto:cds-snc@servicecanada.gc.ca)"
+  other: "Do you think this page is missing something important? Or maybe you have a suggestion to make it better? We’d love to hear from you!"
+toolkit-feedback-text-email:
+  other: "Share your feedback with us at: <gcds-link href='mailto:cds-snc@servicecanada.gc.ca'>CDS-SNC@servicecanada.gc.ca</gcds-link>"
 toolkit-resources:
   other: "Resources"
 toolkit-tools:

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -323,8 +323,12 @@ view-tags:
 
 toolkit-credits:
   other: "Illustration fournie par Storyset"
+toolkit-feedback-title: 
+  other: "Aidez-nous à nous améliorer"
 toolkit-feedback-text:
-  other: "Croyez-vous qu'il manque quelque chose d'important sur cette page? Ou peut-être avez-vous une suggestion pour l'améliorer? Nous aimerions avoir votre avis! Partagez vos commentaires avec nous à : [cds-snc@servicecanada.gc.ca](mailto:cds-snc@servicecanada.gc.ca)"
+  other: "Croyez-vous qu'il manque quelque chose d'important sur cette page? Ou peut-être avez-vous une suggestion pour l'améliorer? Nous aimerions avoir votre avis!"
+toolkit-feedback-text-email:
+  other: "Partagez vos commentaires avec nous à : <gcds-link href='mailto:cds-snc@servicecanada.gc.ca'>CDS-SNC@servicecanada.gc.ca</gcds-link>"
 toolkit-resources:
   other: "Ressources"
 toolkit-name:

--- a/layouts/partials/toolkit-feedback.html
+++ b/layouts/partials/toolkit-feedback.html
@@ -8,5 +8,7 @@
 
 <div class="toolkit-feedback" style="padding: 40px 0">
   <hr />
-  <gcds-text>{{ i18n "toolkit-feedback-text" | markdownify }}</gcds-text>
+  <h2 id="toolkitFeedback">{{ i18n "toolkit-feedback-title" }}</h2>
+  <gcds-text>{{ i18n "toolkit-feedback-text" }}</gcds-text>
+  <gcds-text>{{ i18n "toolkit-feedback-text-email" | safeHTML }}</gcds-text>
 </div>

--- a/layouts/partials/toolkit-subtopic-nav.html
+++ b/layouts/partials/toolkit-subtopic-nav.html
@@ -43,5 +43,6 @@ The partial renders the following components:
       <gcds-nav-link href="#{{ $h2id }}">{{ $h2header }}</gcds-nav-link>
       {{ end }}
     {{ end }}
+    <gcds-nav-link href="#toolkitFeedback">{{ i18n "toolkit-feedback-title" | markdownify }}</gcds-nav-link>
   </gcds-side-nav>
 </gcds-container>

--- a/layouts/partials/toolkit-topic-nav.html
+++ b/layouts/partials/toolkit-topic-nav.html
@@ -98,5 +98,6 @@ The partial uses the following shortcodes:
       {{ end }}
     </gcds-nav-group>
     {{ end }}
+    <gcds-nav-link href="#toolkitFeedback">{{ i18n "toolkit-feedback-title" | markdownify }}</gcds-nav-link>
   </gcds-side-nav>
 </gcds-container>


### PR DESCRIPTION
# Summary | Résumé
Recieved feedback to make the call-to-action for contribution a little more prominent. Worked off of [these designs](https://www.figma.com/design/9uecebSmuMHxmO7Pxv3J3x/S%26D-Toolkit?node-id=717-7777&p=f&t=CNGSgOUJMOevBCGF-0).

Following that, we:
- modified the copy for improvement/feedback a bit
- added a header to the section
- linked it out in the side navigation for a little extra prominence
- updated to use gcds email link for the little icon ( also the email link is now the proper colour )

| Before | After |
|--------|-------|
|    <img width="1185" alt="image" src="https://github.com/user-attachments/assets/a6087acc-717f-46cc-9f08-78af772b8478" />    |   <img width="1225" alt="image" src="https://github.com/user-attachments/assets/dbe64190-c4be-40da-8c0d-5efc014b0396" />   |  
| <img width="852" alt="image" src="https://github.com/user-attachments/assets/e3e18ba0-05d6-478a-ac49-4b824c70225e" />  |  <img width="892" alt="image" src="https://github.com/user-attachments/assets/7363fd06-29ec-45b2-ba06-0345b78f5171" /> |

## French copy
| Sidenav | Feedback|
|--------|-------|
| <img width="1191" alt="image" src="https://github.com/user-attachments/assets/15c24d0a-7df5-4d5f-8a16-89adc42ef251" /> | <img width="827" alt="image" src="https://github.com/user-attachments/assets/d21ae24f-eb1f-4a84-93cb-67ba6ceec760" /> |




