### PR TITLE
GCDS product card on English homepage

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -8,7 +8,7 @@ sections:
       - gc-forms
   - title: "Designing digital products"
     products:
-      - gc-design-systems
+      - gc-design-system
       - design-for-canada-ca
   - title: "Guidance"
     products:


### PR DESCRIPTION
Fixing a small typo to bring back the English GCDS product card to the [Homepage](https://digital.canada.ca/).

Before: 
<img width="1112" alt="Screenshot 2025-03-28 at 9 38 19 AM" src="https://github.com/user-attachments/assets/d8d629cb-8f8a-46a1-95e1-afff6efd1205" />

After:
<img width="1091" alt="Screenshot 2025-03-28 at 9 38 36 AM" src="https://github.com/user-attachments/assets/7c2021b9-8ad7-41df-9050-c02a68ab2384" />
