### PR TITLE
Update French topic card on toolkit Homepage

### DIFF
--- a/content/fr/les-outils-du-numeriques-et-de-services/prestation-de-service-agile/_index.md
+++ b/content/fr/les-outils-du-numeriques-et-de-services/prestation-de-service-agile/_index.md
@@ -1,6 +1,6 @@
 ---
 date: 2025-03-05
-description: Implement continuous, iterative delivery to keep up with users’ evolving needs.
+description: Mettre en œuvre une livraison continue et itérative qui suit l’évolution des besoins des personnes faisant appel à vos services.
 layout: list
 img_url: /img/toolkit/agile.svg
 tools:


### PR DESCRIPTION
The topic card description on the [Service and Digital Toolkit's French Homepage](https://numerique.canada.ca/les-outils-du-numeriques-et-de-services/) (under "Prestation de service agile") is in English. This PR includes a fix, updating the description to a French one.

**Before:** 
![image (14)](https://github.com/user-attachments/assets/e8f9c2cc-3572-4b49-97f6-dfddfd45ccfc)

**After:**
<img width="1135" alt="Screenshot 2025-03-31 at 9 05 36 AM" src="https://github.com/user-attachments/assets/97718f0b-1be8-4b70-aa13-710fef36d0c0" />
