### PR TITLE
Fix/toolkit padding

### DIFF
--- a/assets/sass/cds/_toolkit-general.scss
+++ b/assets/sass/cds/_toolkit-general.scss
@@ -23,6 +23,7 @@ body {
 
 #wb-cont {
     max-width: var(--gcds-container-xl);
+    width: 90%;
     margin: 0 auto;
 }
 

--- a/assets/sass/cds/_toolkit-nav.scss
+++ b/assets/sass/cds/_toolkit-nav.scss
@@ -20,3 +20,16 @@
     background-image: url("../img/toolkit/cds-toolkit-logo-blk-fr.svg");
   }
 }
+
+
+.topic-nav-mobile-heading {
+  font: var(--gcds-side-nav-heading-font);
+  margin-block-end: var(--gcds-side-nav-heading-margin);
+  margin-top: 0;
+}
+
+@media only screen and (min-width: 64em) {
+  .topic-nav-mobile-heading {
+    display: none;
+  }
+}

--- a/assets/sass/toolkit.scss
+++ b/assets/sass/toolkit.scss
@@ -1,6 +1,5 @@
 // General toolkit styles
 @import "cds/toolkit-reset";
 @import "cds/variables";
-@import "cds/variables";
 @import "cds/toolkit-general";
 @import "cds/toolkit-nav";

--- a/layouts/partials/toolkit-subtopic-nav.html
+++ b/layouts/partials/toolkit-subtopic-nav.html
@@ -17,6 +17,8 @@ The partial renders the following components:
 */}}
 
 <gcds-container tag="aside">
+  <h2 aria-hidden="true" class="topic-nav-mobile-heading">On this page</h2>
+  <a class="sr-only" href="#pageContent">Skip to page content</a>
   <gcds-side-nav label='{{ i18n "on-this-page" }}'>
     <!-- Content outline group -->
     {{ $h2headers := findRE `<gcds-heading tag="h2".*?>(.|\n)*?</gcds-heading>` .Content }}

--- a/layouts/partials/toolkit-topic-nav.html
+++ b/layouts/partials/toolkit-topic-nav.html
@@ -17,6 +17,7 @@ The partial uses the following shortcodes:
  */}}
 
 <gcds-container tag="aside">
+  <h2 aria-hidden="true" class="topic-nav-mobile-heading">On this page</h2>
   <gcds-side-nav label='{{ i18n "on-this-page" }}'>
     {{ $currentPage := . }}
     <!-- Topic sub-pages group -->

--- a/layouts/partials/toolkit-topic-nav.html
+++ b/layouts/partials/toolkit-topic-nav.html
@@ -18,6 +18,7 @@ The partial uses the following shortcodes:
 
 <gcds-container tag="aside">
   <h2 aria-hidden="true" class="topic-nav-mobile-heading">On this page</h2>
+  <a class="sr-only" href="#pageContent">Skip to page content</a>
   <gcds-side-nav label='{{ i18n "on-this-page" }}'>
     {{ $currentPage := . }}
     <!-- Topic sub-pages group -->

--- a/layouts/toolkit/list.html
+++ b/layouts/toolkit/list.html
@@ -12,7 +12,7 @@
     <section>
       <gcds-heading tag="h2">{{ i18n "toolkit-resources" }}</gcds-heading>
         
-      <gcds-grid columns="1fr 1fr" columns-desktop="1fr 1fr" columns-tablet=" 1fr 1fr">
+      <gcds-grid columns="1fr" columns-desktop="1fr 1fr" columns-tablet="1fr">
         {{ range .Pages }}
         <gcds-card
         card-title="{{ .Title }}"

--- a/layouts/toolkit/list.html
+++ b/layouts/toolkit/list.html
@@ -4,7 +4,7 @@
   
   {{ partial "toolkit-topic-nav.html" . }}
   
-  <gcds-container tag="main">
+  <gcds-container tag="main" id="pageContent">
     <gcds-heading tag="h1">{{ .Title }}</gcds-heading>
     {{ .Content }}
     
@@ -12,7 +12,7 @@
     <section>
       <gcds-heading tag="h2">{{ i18n "toolkit-resources" }}</gcds-heading>
         
-      <gcds-grid columns="1fr" columns-desktop="1fr 1fr" columns-tablet="1fr">
+      <gcds-grid columns="1fr" columns-desktop="1fr 1fr" columns-tablet="1fr 1fr">
         {{ range .Pages }}
         <gcds-card
         card-title="{{ .Title }}"

--- a/layouts/toolkit/sub-list.html
+++ b/layouts/toolkit/sub-list.html
@@ -3,11 +3,11 @@
 {{ end }}
 
 {{ define "main" }}
-    <gcds-grid columns="1fr 3fr" columns-desktop="1fr 3fr" columns-tablet="1fr">
+    <gcds-grid columns="1fr" columns-desktop="1fr 3fr" columns-tablet="1fr">
 
         {{ partial "toolkit-subtopic-nav.html" . }}
         
-        <gcds-container tag="main">
+        <gcds-container tag="main" id="pageContent">
             <gcds-heading tag="h1">{{ .Title }}</gcds-heading>
             {{ .Content }}
             {{ partial "toolkit-feedback.html" . }}


### PR DESCRIPTION
# Summary | Résumé

This PR takes care of a couple small things/issues.

## Topic menu and page padding 
- Added 90% width to pages, in line with GCDS (solves the padding issue on mobile that was brought up to us).
- Added a header to “on this page” to add clarity about menus, since gcds menu button text cannot be changed.
-  Fixed columns on subtopic pages (it was doing 2 columns, when it should drop to 1 on mobile)

| Before | After |
|--------|-------|
|   <img width="546" alt="image" src="https://github.com/user-attachments/assets/2c92d633-12ec-42b0-bf6d-0edf6229a731" />   |   
<img width="547" alt="image" src="https://github.com/user-attachments/assets/1fe1eb02-6e76-4f3c-9966-d990dcac8a4f" />
    |

## Fixed an issue with resource cards on mobile, where it wasn't dropping to 1 column.
| Before | After |
|--------|-------|
|  <img width="540" alt="image" src="https://github.com/user-attachments/assets/7b04e49d-a79c-448f-a237-254abe53886d" />   |   <img width="542" alt="image" src="https://github.com/user-attachments/assets/2b474a00-d285-49e0-9ecf-debc485eb95e" />   |


## Non-visual changes
- Deleted duplicate scss include of cds variables in `toolkit.scss` file.
- Added “skip to page content" link in the page/topic navigation (`layouts/partials/toolkit-subtopic-nav.html` and `layouts/partials/toolkit-topic-nav.html`), so screen reader users can skip to the content and not be forced to go through the side navigation. 


