### PR TITLE
Add data-gc-analytics-exit attribute for improved tracking

### DIFF
--- a/layouts/partials/toolkit-related-blog-posts.html
+++ b/layouts/partials/toolkit-related-blog-posts.html
@@ -36,6 +36,7 @@ The section expects a list of blog post URLs to be passed in as a parameter. The
             card-title="{{ .Title }}"
             card-title-tag="h3"
             href="{{ .RelPermalink }}"
+            data-gc-analytics-exit="{{ .Title }}"
           >
           </gcds-card>
         {{ else }}
@@ -46,6 +47,7 @@ The section expects a list of blog post URLs to be passed in as a parameter. The
               card-title="{{ .Title }}"
               card-title-tag="h3"
               href="{{ .RelPermalink }}"
+              data-gc-analytics-exit="{{ .Title }}"
             >
             </gcds-card>
           {{ else }}
@@ -56,6 +58,7 @@ The section expects a list of blog post URLs to be passed in as a parameter. The
                 card-title="{{ .Title }}"
                 card-title-tag="h3"
                 href="{{ .RelPermalink }}"
+                data-gc-analytics-exit="{{ .Title }}"
               >
               </gcds-card>
             {{ end }}
@@ -72,6 +75,7 @@ The section expects a list of blog post URLs to be passed in as a parameter. The
             card-title="{{ $blogPost.Title }}"
             card-title-tag="h3"
             href="{{ $blogPost.RelPermalink }}"
+            data-gc-analytics-exit="{{ $blogPost.Title }}"
           >
           </gcds-card>
         {{ end }}

--- a/layouts/partials/toolkit-resources.html
+++ b/layouts/partials/toolkit-resources.html
@@ -22,6 +22,7 @@ The partial expects the following parameters to be passed in the front matter of
         card-title-tag="h3"
         href="{{ .url }}"
         description="{{ .description }}"
+        data-gc-analytics-exit="{{ .text }}"
       >
       </gcds-card>
     {{ end }}

--- a/layouts/partials/toolkit-tools.html
+++ b/layouts/partials/toolkit-tools.html
@@ -35,6 +35,7 @@ The toolkit-tools.html partial can be included in any page to display a list of 
           card-title-tag="h3"
           href="{{ .Params.link }}"
           description="{{ .Description }}"
+          data-gc-analytics-exit="{{ .Title }}"
         >
         </gcds-card>
       {{ end }}

--- a/layouts/toolkit/landing.html
+++ b/layouts/toolkit/landing.html
@@ -42,6 +42,7 @@
             card-title-tag="h3"
             href="{{ .RelPermalink }}"
             description="{{ .Description }}"
+            data-gc-analytics-exit="{{ .Title }}"
           >
           </gcds-card>
         {{ end }}

--- a/layouts/toolkit/list.html
+++ b/layouts/toolkit/list.html
@@ -19,6 +19,7 @@
         href="{{ .RelPermalink }}"
         card-title-tag="h3"
         description="{{ .Description }}"
+        data-gc-analytics-exit="{{ .Title }}"
         ></gcds-card>
         {{ end }}
       </gcds-grid>


### PR DESCRIPTION
Add the `data-gc-analytics-exit` attribute to various sections, enhancing analytics tracking for blog posts, resources, tools, and lists.