### PR TITLE
Add job posting for Platform Technician position in English and French

### DIFF
--- a/content/en/jobs/platform-technician.md
+++ b/content/en/jobs/platform-technician.md
@@ -1,0 +1,53 @@
+---
+archived: false
+description: >-
+ This role is a 1-year term position and is classified as an IT-01 in the [Information Technology (IT)](https://www.tbs-sct.canada.ca/agreements-conventions/view-visualiser-eng.aspx?id=31), English essential. This fully remote position is open to applicants located anywhere in the country.  For this opportunity, priority will be given to candidates currently employed by the Federal Public Service.
+layout: job-posting
+leverId: 77d1c499-8722-41ad-9985-e163d76b0e39
+linkHidden: false
+title: 'Platform Technician  — Digital Transformation Office'
+translationKey: platform-technician-mar-2025
+type: section
+---
+
+## About CDS
+
+We believe that public services should be easy to use, secure, reliable, accessible and inclusive for everyone — especially those most in need — and we want your help\!
+
+The Canadian Digital Service (CDS) is part of Employment and Social Development Canada (ESDC). We aim to advance the goals of the [Digital Ambition](https://www.canada.ca/en/government/system/digital-government/government-canada-digital-operations-strategic-plans/canada-digital-ambition.html) and improve service experiences in the Government of Canada.
+
+## About the Digital Transformation Office
+
+The Digital Transformation Office leads design and strategy for Canada.ca, establishing web standards and performance metrics for the Government of Canada. They provide guidance and tools to ensure a consistent, high-quality user experience across government websites.
+
+## The Digital Transformation Office is hiring a Platform Technician\!
+
+This role is a 1-year term position and is classified as an IT-01 in the [Information Technology (IT)](https://www.tbs-sct.canada.ca/agreements-conventions/view-visualiser-eng.aspx?id=31), English essential. This fully remote position is open to applicants located anywhere in the country.  For this opportunity, priority will be given to candidates currently employed by the Federal Public Service.
+
+### Principal Duties and Responsibilities:
+
+* Support the development and maintenance of DTO’s research and data products for Canada.ca, hosted in a secure cloud environment, ensuring they are well maintained, consistently available and easy to use   
+* Participate in maintaining and improving DTO’s DevOps practices, including continuous integration and delivery, microservices and pipelines   
+* Develop, write, modify, integrate and test web site related code and web application code  
+  * Conduct tests and analyze data to monitor quality, security, user interface experiences and to identify areas for improvement  
+  * Develop and implement procedures for ongoing web application revision  
+  * Monitor and maintain web application functionality  
+* Analyze and troubleshoot support tickets and problems through troubleshooting, root cause analysis, and cross-team collaboration to resolve issues across DTO’s platform products  
+* Help maintain and improve technical documentation associated with DTO’s products, processes and development environments   
+* Work on an interdisciplinary product team alongside other subject matter experts, supporting efforts to mature products and tools for Canada.ca
+
+**Qualifications:** 
+
+* Familiarity with technical troubleshooting and analysis;  
+* Proficiency in scripting/programming languages: Javascript, Java, and Python;  
+* Familiarity with cloud services like AWS and/or Azure for modern applications and scaling.  
+* Familiarity with Git and GitHub workflows;  
+* Application of a data-driven approach to problem solving; you enjoy making sense of trends and using the insights to better improve our “users” (Government of Canada peers) experience;  
+* Utilization of the right blend of professionalism and friendliness in all communications;  
+* Promoting inclusive delivery and upholding impact, openness, integrity and fairness;  
+* Asset: Experience with Containerization and IaC: Experienced in using Docker for application deployment and Terraform for automating infrastructure provisioning and management.  
+* Asset: Experience with CI/CD (Continuous Integration/Continuous Deployment): Familiar with setting up and maintaining automated pipelines to ensure efficient, reliable, and scalable software deployment.
+
+We recognize that everyone brings skills and experiences to the table and that not everyone “checks all the boxes”. Apply anyway\! Tell us why you’re the right fit for the job.
+
+CDS welcomes all applicants, including Veterans and people of all races, ethnicities, religions, sexual orientations, gender identities and expressions, national origins, disabilities, ages, body sizes and including those with diverse households and family commitments. We are committed to providing an inclusive and barrier-free work environment, starting with the hiring process. If you need to be accommodated during any phase of the evaluation process, please use the Contact information on this [page](https://www.canada.ca/en/public-service-commission/services/assessment-accommodation-page.html) to request specialized accommodation. All information received in relation to accommodation will be kept confidential.

--- a/content/fr/jobs/technicien-ne-de-la-plateforme.md
+++ b/content/fr/jobs/technicien-ne-de-la-plateforme.md
@@ -1,0 +1,53 @@
+---
+archived: false
+description: >-
+ Ce rôle est un poste de durée déterminée de 1 an et est classé IT-01 dans le groupe [Technologies de l'information (IT)](https://www.tbs-sct.canada.ca/agreements-conventions/view-visualiser-eng.aspx?id=31) au profil linguistique « anglais essentiel ». Ce poste entièrement en télétravail est ouvert aux candidats et candidates dans tout le pays. Pour cette opportunité, la priorité sera donnée aux candidats actuellement employés par la fonction publique fédérale.
+layout: job-posting
+leverId: 77d1c499-8722-41ad-9985-e163d76b0e39
+linkHidden: false
+title: 'Technicien(ne) de la plateforme — Bureau de la transformation numérique'
+translationKey: platform-technician-mar-2025
+type: section
+---
+
+## À propos du SNC
+
+Nous sommes de l’avis que les services publics doivent être conviviaux, sécurisés, fiables, accessibles et inclusifs : ils doivent fonctionner pour tout le monde, en particulier pour ceux et celles qui en ont le plus besoin. C’est pourquoi nous sollicitons votre aide\!
+
+Le Service numérique canadien (SNC) fait partie d’Emploi et Développement social Canada (EDSC). Il cherche à faire progresser les objectifs de l’[Ambition numérique](https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/plans-strategiques-operations-numeriques-gouvernement-canada/ambition-numerique-canada.html) et à améliorer l’expérience d’utilisation des services du gouvernement du Canada.
+
+## À propos du Bureau de la transformation numérique
+
+Le Bureau de la transformation numérique dirige la conception et la stratégie pour Canada.ca en établissant des normes Web et des mesures de performance pour le gouvernement du Canada. Il fournit de l’orientation et des outils afin que l’expérience utilisateur soit cohérente et de haute qualité pour l’ensemble des sites Web du gouvernement.
+
+## Le Bureau de la transformation numérique est à la recherche d’un·e technicien·ne de la plateforme\!
+
+Ce rôle est un poste de durée déterminée de 1 an et est classé IT-01 dans le groupe [Technologies de l'information (IT)](https://www.tbs-sct.canada.ca/agreements-conventions/view-visualiser-eng.aspx?id=31) au profil linguistique « anglais essentiel ». Ce poste entièrement en télétravail est ouvert aux candidats et candidates dans tout le pays. Pour cette opportunité, la priorité sera donnée aux candidats actuellement employés par la fonction publique fédérale. 
+
+### Fonctions et responsabilités principales&nbsp;:
+
+* Soutenir le développement et la maintenance des produits de recherche et de données du BTN pour Canada.ca, hébergés dans un environnement cloud sécurité, en veillant à ce qu’ils soient bien maintenus, constamment disponibles et faciles à utiliser.  
+* Participer au maintien et à l’amélioration des pratiques DevOps du BTN, y compris l’intégration et livraison continues, les microservices et les pipelines.  
+* Développer, écrire, modifier, intégrer et tester les codes liés au site web et les codes d’application web.  
+* Effectuer des tests et analyser les données pour surveiller la qualité, la sécurité, les expériences de l’interface utilisateur et identifier des zones d’amélioration.  
+* Développer et mettre en oeuvre des procédures pour la révision continue des applications web.  
+* Surveiller et maintenir les fonctionnalités des applications web.  
+* Analyser et résoudre des tickets de support  et des problèmes par le biais de réalisation de diagnostics, d’analyse des causes profondes et de la collaboration avec les autres équipes afin de résoudre les problèmes sur l’ensemble des produits de la plateforme BTN.  
+* Aider à assurer le maintien et l’amélioration de la documentation technique associée aux environnements clients pris en charge.  
+* Travailler au sein d’une équipe de produits multidisciplinaire avec d’autres experts en la matière, en soutenant les efforts de développement des produits et outils pour Canada.ca.
+
+### Qualifications&nbsp;:
+
+* Familiarité avec l’analyse et la résolution de problèmes techniques.  
+* Maitrîse des langages de script/programmation: JavaScript, Java et Python.  
+* Familiarité avec les services cloud comme AWS et/ou Azure pour les applications modernes et leurs croissances  
+* Application d’une approche axée sur les données pour résoudre les problèmes; vous aimez comprendre les tendances et utiliser ces connaisasnces pour améliorer l’expérience de nos “utilisateurs” (vos pairs du Gouvernement du Canada).  
+* Utilisation d’un bon mélange de professionnalisme et d’amabilité dans toutes vos communications.  
+* Capacité à promouvoir la prestation inclusive, l’incidence durable, ainsi que le travail transparent, intègre et équitable.  
+* Atout: Expérience de la conteneurisation et de l’IaC: expérience d’utilisation de Docker pour le déploiement d’applications et de Terraform pour l’automatisation de l’approvisionnement et de la gestion de l’infrastructure.  
+* Atout: Expérience avec CI/CD (intégration continue/déploiement continu): Familiarité avec la mise en place et le maintien de pipelines automatisés pour assurer un déploiement efficace, fiable et évolutif des logiciels.
+
+
+Nous savons que tout le monde présente des compétences et des expériences différentes, et que personne ne répond parfaitement à toutes les exigences. Postulez quand même\! Dites-nous pourquoi vous êtes un candidat ou une candidate de choix.
+
+Le SNC accueille toutes les personnes candidates, peu importe leur race, ethnicité, religion, orientation sexuelle, identité et expression de genre, origine nationale, handicap, âge et taille corporelle, y compris les vétérans et les personnes qui ont des engagements familiaux divers. Nous sommes aussi engagé·e·s à instaurer un milieu de travail inclusif et exempt d’obstacles, dès le processus de sélection. Si vous avez besoin de mesures d’adaptation à une étape ou une autre du processus d’évaluation, veuillez utiliser les coordonnées indiquées dans le lien ci-dessous pour en faire la demande. Tout renseignement concernant les mesures d’adaptation sera traité confidentiellement. Ce poste entièrement en télétravail est ouvert aux candidats et candidates dans tout le pays.


### PR DESCRIPTION
Add a new job posting for the Platform Technician role, available in both English and French, detailing responsibilities, qualifications, and the inclusive hiring approach. This position is fully remote and prioritizes candidates currently employed by the Federal Public Service.