### PR TITLE
fix tools translation in toolkit topic nav

### DIFF
--- a/layouts/partials/toolkit-topic-nav.html
+++ b/layouts/partials/toolkit-topic-nav.html
@@ -33,7 +33,7 @@ The partial uses the following shortcodes:
 
     <!-- Tools group -->
     {{ if (index .CurrentSection.Params "tools") }}
-    <gcds-nav-group open-trigger="Tools" menu-label='{{ i18n "toolkit-tools" }}'>
+    <gcds-nav-group open-trigger="{{ i18n "toolkit-tools" }}" menu-label='{{ i18n "toolkit-tools" }}'>
       {{ range (index .CurrentSection.Params "tools") }}
         {{ $toolSlug := . }}
         {{ $found := false }}


### PR DESCRIPTION
# Summary | Résumé

Had an issue where "Tools" was hardcoded to just the english in the the topic nav on the toolkit pages. Updated to correctly pull from the i18n string. Thank you to Janice for the flag!

| Before | After |
|--------|-------|
|  <img width="311" alt="image" src="https://github.com/user-attachments/assets/7d47a9d5-e050-4634-ad47-4f25861003f2" />  |  <img width="302" alt="image" src="https://github.com/user-attachments/assets/aa1f3788-5df7-4209-b54e-cb9c6be0f860" />  |
