### PR TITLE
update and correct a line on the toolkit about page

### DIFF
--- a/content/en/service-digital-toolkit/about.md
+++ b/content/en/service-digital-toolkit/about.md
@@ -12,10 +12,7 @@ Whether you’re adopting agile ways of working, designing accessible services, 
 
 ## What’s inside?
 
-Built on real experiences and learnings from the Canadian Digital Service (CDS) and its partners, the SDT offers flexible, structured and bilingual guidance on:
-Agile service delivery
-User-centred design
-Accessibility
+Built on real experiences and learnings from the Canadian Digital Service (CDS) and its partners, the SDT offers flexible, structured and bilingual guidance on: accessibility, agile service delivery and user-centred design.
 
 ## Help shape the toolkit
 

--- a/content/fr/les-outils-du-numeriques-et-de-services/a-propos.md
+++ b/content/fr/les-outils-du-numeriques-et-de-services/a-propos.md
@@ -11,10 +11,7 @@ Qu’il s’agisse d’adopter des méthodes de travail agiles, de concevoir des
 
 ## Qu’est-ce qu’on y retrouve?
 
-S’appuyant sur des expériences réelles et des leçons apprises par le Service numérique canadien (SNC) et ses partenaires, les ONS offrent des conseils souples, structurés et bilingues sur les sujets suivants&nbsp;:
- Prestation de services agile
-Conception centrée sur la personne
-Accessibilité
+S’appuyant sur des expériences réelles et des leçons apprises par le Service numérique canadien (SNC) et ses partenaires, les ONS offrent des conseils souples, structurés et bilingues sur les sujets suivants : accessibilité, prestation de services agile, et conception centrée sur la personne.
 
 ## Contribuez à façonner les outils
 


### PR DESCRIPTION
# Summary | Résumé

The toolkit about page was missing some needed commas, flagged (and content updated) by Janice ✨. 
Updated according to messages shared in slack. 

| Before | After |
|--------|-------|
|  <img width="758" alt="image" src="https://github.com/user-attachments/assets/04b90842-d673-47d8-b8f6-ee8c46a55051" />  |  <img width="761" alt="image" src="https://github.com/user-attachments/assets/7d021fcb-b71d-416b-a346-f42ff4bb467b" />  |
|  <img width="778" alt="image" src="https://github.com/user-attachments/assets/0a4d537d-414a-4acb-b0b8-8d38537e9bbb" />  |  <img width="783" alt="image" src="https://github.com/user-attachments/assets/5ad21287-8611-4c5a-adc9-0a38382d0c29" />  |