### PR TITLE
chore: remove List Manager service

### DIFF
--- a/content/en/security-notice.html
+++ b/content/en/security-notice.html
@@ -42,8 +42,6 @@ aliases: [/legal/security-notice/, /avis-de-securite/, /transparence/avis-de-sec
                     <li>design-system.alpha.canada.ca</li>
                     <li>articles.alpha.canada.ca</li>
                     <li>forms-formulaires.alpha.canada.ca</li>
-                    <li>list-manager.alpha.canada.ca</li>
-
                     <li>scan-files.alpha.canada.ca</li>
 
                 </ul>

--- a/content/fr/security-notice.html
+++ b/content/fr/security-notice.html
@@ -36,8 +36,6 @@ aliases: [/transparence/avis-de-securite/, /security-notice/]
                     <li>systeme-design.alpha.canada.ca</li>
                     <li>articles.alpha.canada.ca</li>
                     <li>forms-formulaires.alpha.canada.ca</li>
-                    <li>list-manager.alpha.canada.ca</li>
-
                     <li>scan-files.alpha.canada.ca</li>
 
                 </ul>


### PR DESCRIPTION
# Summary
The service is being shutdown so its URL can be removed from the security notice.

# Related
- https://github.com/cds-snc/site-reliability-engineering/issues/1495