### PR TITLE
temporarily hide tags for testing

### DIFF
--- a/assets/sass/cds/_blog.scss
+++ b/assets/sass/cds/_blog.scss
@@ -121,6 +121,7 @@
   }
 
   .tags {
+    visibility: hidden;
     margin-top: var( --gcds-spacing-400 );
 
     a {

--- a/layouts/section/blog.html
+++ b/layouts/section/blog.html
@@ -9,7 +9,7 @@
 
 
             </div>
-            <div class="col-md-4">
+            <div style="display: none;" class="col-md-4">
                 <aside>
                     <div class="container">
                         <div class="row">


### PR DESCRIPTION
# Summary | Résumé

Temporarily removed side bar and tag visibility for testing purposes.

We need to check to see if manually adding tags for Strapi blogs and updating GC Articles will cause any issues.