### PR TITLE
Feat/add tags to strapi blogs

### DIFF
--- a/content/en/blog/posts/-‘a-percentage-of-perfection’:-incident-management-at-cds.md
+++ b/content/en/blog/posts/-‘a-percentage-of-perfection’:-incident-management-at-cds.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/banner_a_percentage_of_perfection_in
 image-alt: A laptop with an alarming red screen, surrounded by hazard signs, sand timer, settings icon, and life buoy.
 thumb: https://de2an9clyit2x.cloudfront.net/small_banner_a_percentage_of_perfection_incident_management_at_cds_f2f8ea5925.jpeg
 translationKey: security-incident-management-cds
+tags: [""]
 ---
 > *“Accepting that imperfect things still work is fundamental to preventing failures from becoming catastrophes.’’*
 

--- a/content/en/blog/posts/5-tips-to-make-your-presentations-sparkle.md
+++ b/content/en/blog/posts/5-tips-to-make-your-presentations-sparkle.md
@@ -9,7 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/banner_making_presentations_memorabl
 image-alt: A shining green gem in a collection of rocks. It stands out from the rest.
 thumb: https://de2an9clyit2x.cloudfront.net/small_banner_making_presentations_memorable_f9e0ae0042.jpeg
 translationKey: making-presentations-memorable
-tags: ["Design and Communications"]
+tags: [""]
 ---
 Have you ever had the misfortune to sit through a truly awful presentation? Too long, too verbose, visually suffocating, or just plain confusing? 
 

--- a/content/en/blog/posts/7-steps-to-great-visual-storytelling.md
+++ b/content/en/blog/posts/7-steps-to-great-visual-storytelling.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/visual_storyteller_533f467c76.jpg
 image-alt: A picture of a man at a computer designing a visual story about outer space.
 translationKey: visual-storyteller-blog
 thumb: https://de2an9clyit2x.cloudfront.net/small_visual_storyteller_533f467c76.jpg
+tags: [""]
 ---
 Are you looking to make your communications more effective? Let images help you enhance your messages.
 

--- a/content/en/blog/posts/CDS-gets-its-first-CEO.md
+++ b/content/en/blog/posts/CDS-gets-its-first-CEO.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_aaron_snow_eae49285b0.jpg
 image-alt: Aaron Snow
 translationKey: CDS-gets-its-first-CEO
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_aaron_snow_eae49285b0.jpg
+tags: [""]
 ---
 
 In September, Yaprak Baltacıoğlu, Secretary of the Treasury Board, [launched the search for CDS's first CEO.](https://digital.canada.ca/2017/09/12/wanted-ceo-cds/) The global search attracted candidates from all over the world.

--- a/content/en/blog/posts/a-conducting-user-research-with-NRCan.md
+++ b/content/en/blog/posts/a-conducting-user-research-with-NRCan.md
@@ -12,6 +12,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_conducting_user_research_with_N
 image-alt: Eman and Jennifer looking at the Value Proposition Canvas
 translationKey: conducting-user-research-with-NRCan
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_conducting_user_research_with_NRCAN_cb9cb98c0d.jpg
+tags: [""]
 ---
 
 When Natural Resources Canada (NRCan) came to us with the idea of opening up access to EnerGuide data, the solution seemed pretty obvious — build an ‘Application Programming Interface’ (API) that would allow users to query the EnerGuide data; but first, we had to validate whether this proposed solution was the way to go.

--- a/content/en/blog/posts/a-faster-way-to-create-privacy-and-consent-notices-in-government.md
+++ b/content/en/blog/posts/a-faster-way-to-create-privacy-and-consent-notices-in-government.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/en_banner_consent_generator_ecbab1db
 image-alt: A Government of Canada website called “Make a form for intercept recruitment and testing,” displayed on a laptop screen and mobile phone.
 thumb: https://de2an9clyit2x.cloudfront.net/small_en_banner_consent_generator_ecbab1db1c.jpeg
 translationKey: blog-consent-generator
+tags: [""]
 ---
 Providing good services isn't just about technology. It's about meeting the raised expectations of a public that knows exactly where their rideshare is and pays for a coffee with a tap of their phone. It’s about understanding how people navigate the world. To do that, we have to research with people a little and often. 
 

--- a/content/en/blog/posts/a-menagerie-of-government-forms.md
+++ b/content/en/blog/posts/a-menagerie-of-government-forms.md
@@ -16,6 +16,7 @@ image-alt: >-
   one with a tail, one with wings, one with a beak, and one as a butterfly.
 translationKey: form-use-cases
 thumb: https://de2an9clyit2x.cloudfront.net/small_menagerie_banner_3376fc1155.jpg
+tags: [""]
 ---
 > Imagine this: You search the internet for information on how to apply for a permit that you need. It leads you to a government website with seven paragraphs about eligibility. You read it and are still a little unsure if you meet some of the criteria, but decide to apply anyway. The apply button leads you to a prompt to download a PDF document. When you try to open it, it says that you need to download PDF editing software, which you don’t have and don’t want to pay for. You decide to print it off and fill it out by hand. The form is four pages, and 37 questions long. Yikes, this is going to take a while. You decide to leave it until you have a good hour to sit down and tackle it properly. When you finally do a week later, it turns out that only half of the fields apply to you, and for those that do, you’re not even so sure exactly what information you’re being asked to provide. You scan and email the completed form, cross your fingers, and wait.
 

--- a/content/en/blog/posts/always-a-challenge.md
+++ b/content/en/blog/posts/always-a-challenge.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_always_a_challenge_2017_dc42cb6
 image-alt: The homepage of the Impact Canada Challenge Platform
 translationKey: always-a-challenge
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_always_a_challenge_2017_dc42cb6789.jpg
+tags: [""]
 ---
 During our [engagement sessions](/beginning-the-conversation/full-report/), people told us that the government needed to identify ways to enable non-traditional players to work with government and co-create solutions.
 

--- a/content/en/blog/posts/answering-your-questions-about-our-new-platform-to-send-government-emails-and-sms-messages.md
+++ b/content/en/blog/posts/answering-your-questions-about-our-new-platform-to-send-government-emails-and-sms-messages.md
@@ -19,6 +19,7 @@ image-alt: >-
   using the Notify service.
 translationKey: notify-blog2
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_notify2_89a385e31d.jpg
+tags: [""]
 ---
 *Update: Like any digital product, GC Notify is constantly being improved to meet the needs of teams across government.* *For the most up-to-date  information, please refer to the [GC Notify features page](https://notification.canada.ca/features).*
 

--- a/content/en/blog/posts/are-you-the-canadian-digital-service’s-next-ceo?.md
+++ b/content/en/blog/posts/are-you-the-canadian-digital-service’s-next-ceo?.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_next_ceo_banner_en_7617774f94.j
 image-alt: A smartphone beside a book that reads “The next chapter” for the Canadian Digital Service.
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_next_ceo_banner_en_7617774f94.jpg
 translationKey: blog-ceo-job-search
+tags: [""]
 ---
 At the Canadian Digital Service our mission is to change government to serve people better.  It’s no short order, but we know there are people out there who are as obsessed as we are about making government services easy for people to use. We’re looking for a new CEO to help us scale our growth and impact. We’re looking for someone to put the wind at [public servants’ backs](https://digital.canada.ca/roadmap-2025/) and make it easier for everyone in government to practice modern software development and service delivery. If that’s you, we’d love for you to apply.
 

--- a/content/en/blog/posts/assessing-government-training-needs-for-the-future-of-digital-service-delivery.md
+++ b/content/en/blog/posts/assessing-government-training-needs-for-the-future-of-digital-service-delivery.md
@@ -17,6 +17,7 @@ image-alt: >-
   big round tables with laptops and sticky notes during a workshop.
 translationKey: assessing-training-needs
 thumb: https://de2an9clyit2x.cloudfront.net/small_tna_image_cfa9a36c02.jpg
+tags: [""]
 ---
 As the Government of Canada (GC) works to improve how it designs and delivers services, we can look to use new tools, methods and practices to help us build our capacity to get there. People — public servants — remain at the centre of these efforts. So, when we [teamed up](/2018/11/01/dear-colleagues-what-digital-training-do-you-need/) with the Faculty of Management at Dalhousie University late last year to better understand and assess the current training needs for digital disciplines across the GC, we started by talking to public servants. By directly engaging with them, we’re able to build a better understanding of their needs and how we can meet them. The full Report can be found on [Dalhousie’s website](https://bit.ly/30I14wC).
 

--- a/content/en/blog/posts/attracting-and-recruiting-top-talent-with-a-little-help-from-our-friends.md
+++ b/content/en/blog/posts/attracting-and-recruiting-top-talent-with-a-little-help-from-our-friends.md
@@ -11,6 +11,7 @@ image: https://de2an9clyit2x.cloudfront.net/beetletoy_a7a60363e2.jpg
 image-alt: A yellow Volkswagen beetle toy on wooden shelf filled with books.
 translationKey: help-from-friends-HR
 thumb: https://de2an9clyit2x.cloudfront.net/small_beetletoy_a7a60363e2.jpg
+tags: [""]
 ---
 *[We get by with a little help from our friends](https://digital.canada.ca/2019/01/31/we-get-by-with-a-little-help-from-our-friends/) is a blog series profiling the amazing public servants who enable us and our partners to design and deliver better services.*
 

--- a/content/en/blog/posts/automated-testing-blog.md
+++ b/content/en/blog/posts/automated-testing-blog.md
@@ -14,6 +14,7 @@ image-alt: >-
   pointing at the screen of a person across the table, who gives a thumbs-up.
 translationKey: automated-testing-blog
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_automated_testing_76c2e620d6.jpg
+tags: [""]
 ---
 
 On the Natural Resources Canada (NRCan) application programming interface (API) product, we follow a common continuous integration (CI) process, including extensive use of automated testing. In our opinion, CI and automated testing is a fundamental requirement for producing and maintaining high-quality software products.

--- a/content/en/blog/posts/b-colocating-with-NRCan.md
+++ b/content/en/blog/posts/b-colocating-with-NRCan.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_colocating_with_NRCAN_e84609704
 image-alt: Jason and Dave standing in front of the building of Natural Resources Canada
 translationKey: colocating-with-NRCan
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_colocating_with_NRCAN_e846097048.jpg
+tags: [""]
 ---
 
 We are building a public-facing application programming interface (API) for Natural Resources Canada to open up access to EnerGuide Home Energy Ratings data. We talk about the details of this partnership in our post [Conducting user research with NRCan to inform an API build - Part 1](/2018/02/15/a-conducting-user-research-with-nrcan/).

--- a/content/en/blog/posts/being-a-student-at-cds-taught-me-a-lot-about-trusting-myself.md
+++ b/content/en/blog/posts/being-a-student-at-cds-taught-me-a-lot-about-trusting-myself.md
@@ -14,6 +14,7 @@ image-alt: >-
   speaker.
 translationKey: cds-student-trust
 thumb: https://de2an9clyit2x.cloudfront.net/small_jose_blog_header_8527c435f6.jpg
+tags: [""]
 ---
 _Thinking back on my eight months as a student at the Canadian Digital Service (CDS), I have come to learn that empowerment is about trust; trust from your leaders and most importantly trust in yourself._
 

--- a/content/en/blog/posts/building-a-community-of-practice-by-offering-assessments-as-a-service.md
+++ b/content/en/blog/posts/building-a-community-of-practice-by-offering-assessments-as-a-service.md
@@ -15,6 +15,7 @@ image-alt: >-
   notebook.
 translationKey: service-assessments
 thumb: https://de2an9clyit2x.cloudfront.net/small_checklist_bf2f5e5013.jpg
+tags: [""]
 ---
 It takes a community of practice to transform government services. Last year, the Government of Canada introduced its [Digital Standards](https://www.canada.ca/en/government/system/digital-government/government-canada-digital-standards.html). These are a set of principles to help teams deliver better quality digital services for Canadians. Since their release, CDS has been exploring how departments can assess themselves against the Standards.
 

--- a/content/en/blog/posts/building-a-multidisciplinary-team-at-esdc-to-serve-people-better.md
+++ b/content/en/blog/posts/building-a-multidisciplinary-team-at-esdc-to-serve-people-better.md
@@ -15,6 +15,7 @@ image: https://de2an9clyit2x.cloudfront.net/mic_6347afc292.jpg
 image-alt: condenser microphone with black background
 translationKey: building-a-multidisciplinary-team-at-ESDC-to-serve-people-better
 thumb: https://de2an9clyit2x.cloudfront.net/small_mic_6347afc292.jpg
+tags: [""]
 ---
 As a manager under the Canada Pension Plan Service Improvement Strategy at Employment and Social Development Canada (ESDC) I helped create the multidisciplinary team at the Canadian Digital Service (CDS) working on improving the Canada Pension Plan (CPP) for people applying for disability benefits.
 

--- a/content/en/blog/posts/building-a-research-plan.md
+++ b/content/en/blog/posts/building-a-research-plan.md
@@ -12,6 +12,7 @@ image-alt: >-
   the right.
 translationKey: building-a-research-plan
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_building_a_research_plan_54517b04ce.jpg
+tags: [""]
 ---
 
 A good discovery phase arms you with all the information you need to define the problem(s) you want to solve. Our discovery phase helped gather evidence that there’s a need for more awareness amongst Veterans on how to access the many programs, services, and benefits available to them through Veterans Affairs Canada (VAC).

--- a/content/en/blog/posts/building-an-effective-exposure-notification-service-like-covid-alert.md
+++ b/content/en/blog/posts/building-an-effective-exposure-notification-service-like-covid-alert.md
@@ -12,6 +12,7 @@ image: https://de2an9clyit2x.cloudfront.net/covid_alert_vision_banner_5a8a8a87f1
 image-alt: 'A scale, balancing people using the COVID Alert app in the middle. '
 translationKey: covid-alert-utility-scale
 thumb: https://de2an9clyit2x.cloudfront.net/small_covid_alert_vision_banner_5a8a8a87f1.jpg
+tags: [""]
 ---
 *On July 31, 2020, we released COVID Alert, Canada’s COVID-19 exposure notification service.
 The app was built in the open. Continuing in that vein, we’ll be sharing posts that explain the reasons behind the choices we’re making as we continue to update, test, and iterate on this service.*

--- a/content/en/blog/posts/building-for-learning-and-iteration-with-our-web-search-bar.md
+++ b/content/en/blog/posts/building-for-learning-and-iteration-with-our-web-search-bar.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/EN_Search_bar_iteration_cb9d810c68.j
 image-alt: Graphic illustration of a team iterating on and improving a website search bar together. 
 thumb: https://de2an9clyit2x.cloudfront.net/small_EN_Search_bar_iteration_cb9d810c68.jpg
 translationKey: blog-website-searchbar-feedback
+tags: [""]
 ---
 If helpful information exists on a website but no one is able to find it, does that information really exist? 
 

--- a/content/en/blog/posts/building-inclusive-services-is-not-about-perfection.md
+++ b/content/en/blog/posts/building-inclusive-services-is-not-about-perfection.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/mg_9837_2_7bc5f33d0f.jpg
 image-alt: A man uses a split keyboard and other technologies to help use his computer.
 translationKey: not-perfect
 thumb: https://de2an9clyit2x.cloudfront.net/small_mg_9837_2_7bc5f33d0f.jpg
+tags: [""]
 ---
 Accessibility has a reputation for being hard and sometimes even unobtainable. But building inclusive services that work better for everyone isn’t about perfection. It’s about making an effort and seeing progress. When we bring that type of effort every day, transformation happens. On the flip side, when we don’t, the people who may need our services most can’t access them.
 

--- a/content/en/blog/posts/busting-talent-myths-to-hire-multidisciplinary-teams.md
+++ b/content/en/blog/posts/busting-talent-myths-to-hire-multidisciplinary-teams.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/banner_ochro_blog_8f66eccf8f.jpeg
 image-alt: A quilt woven together with different patches, designs and team members.
 thumb: https://de2an9clyit2x.cloudfront.net/small_banner_ochro_blog_8f66eccf8f.jpeg
 translationKey: blog-busting-talent-myths
+tags: [""]
 ---
 *Note: A previous version of this blog was posted in error.*
 

--- a/content/en/blog/posts/can-you-engineer-cds’s-software-dev-community.md
+++ b/content/en/blog/posts/can-you-engineer-cds’s-software-dev-community.md
@@ -15,6 +15,7 @@ image-alt: >-
   Meeting.
 translationKey: blog-head-software-dev
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_head_software_dev_4d582ff210.jpg
+tags: [""]
 ---
 The digital government and civic tech communities talk a lot about how to make government more effective at delivering life-changing services. Things like agile practices, design thinking, and using modern technology are commonplace. At the Canadian Digital Service (CDS), we believe in the value of putting “people first,” which is why hiring the right person is critical, and more important than these processes and tools.
 

--- a/content/en/blog/posts/challenging-our-assumption.md
+++ b/content/en/blog/posts/challenging-our-assumption.md
@@ -7,6 +7,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_accessibility_2018_52c1550c88.j
 image-alt: Keyboard with keys representing accessibility features
 translationKey: challenging-our-assumption
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_accessibility_2018_52c1550c88.jpg
+tags: [""]
 ---
 
 We recently received some feedback through our [Github repository](https://github.com/cds-snc/digital-canada-ca) regarding the accessibility of the "hero" images we use on some pages of our website, including the blog posts.

--- a/content/en/blog/posts/civic-leave-embedding-private-sector-talent-in-government-tech.md
+++ b/content/en/blog/posts/civic-leave-embedding-private-sector-talent-in-government-tech.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/small_maple_leafs_652f66ae34.jpg
 image-alt: 'Photo of people side by side, each holding a maple leaf in their hand.'
 translationKey: civic-leave
 thumb: https://de2an9clyit2x.cloudfront.net/small_small_maple_leafs_652f66ae34.jpg
+tags: [""]
 ---
 It takes a variety of skilled people to create and deliver quality government digital services. Here at CDS, we use multi-disciplinary teams to build simple and effective services for Canadians. This requires a team with diverse skills and backgrounds and expertise from different sectors or even  countries.
 

--- a/content/en/blog/posts/co-location-leave-no-team-member-behind.md
+++ b/content/en/blog/posts/co-location-leave-no-team-member-behind.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/colourful_umbrellas_da3560310b.jpg
 image-alt: 'Colourful umbrellas floating side by side in the sky. '
 translationKey: cra-colocation
 thumb: https://de2an9clyit2x.cloudfront.net/small_colourful_umbrellas_da3560310b.jpg
+tags: [""]
 ---
 I can’t believe I’m writing a blog post! As a service owner for this project for the Canada Revenue Agency, it’s one of the things in a long list of “firsts” I’ve encountered since co-locating with our partners at the Canadian Digital Service just over a month ago.
 

--- a/content/en/blog/posts/coding-is-a-team-activity.md
+++ b/content/en/blog/posts/coding-is-a-team-activity.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_team_coding_3f3236a73b.jpg
 image-alt: A computer screen displays 200 lines of JavaScript code in Sublime Text.
 translationKey: coding-is-a-team-activity
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_team_coding_3f3236a73b.jpg
+tags: [""]
 ---
 
 In our experience, software development should be a team effort. This doesn’t mean multiple developers individually contributing code to a single code base; rather, the team as a whole is responsible for each line of code. For any production system, we have an expectation that all code will be approved by at least one other developer, before it is accepted.

--- a/content/en/blog/posts/communication-is-key-a-phonetic-alphabet-for-covid-alert.md
+++ b/content/en/blog/posts/communication-is-key-a-phonetic-alphabet-for-covid-alert.md
@@ -13,6 +13,7 @@ image-alt: >-
   over the phone.
 translationKey: phonetic-alphabet-blog
 thumb: https://de2an9clyit2x.cloudfront.net/small_banner_phonetic_alphabetic_blog_8f889946bb.jpg
+tags: [""]
 ---
 Healthcare workers put themselves at risk to keep us safe. They also play a crucial role in the success of the COVID Alert app.
 

--- a/content/en/blog/posts/community-driven-coding.md
+++ b/content/en/blog/posts/community-driven-coding.md
@@ -11,6 +11,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_david_https_header_b2045a7bfc.j
 image-alt: 'Illustration of two people painting a giant, physical web page.'
 translationKey: community-driven-coding
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_david_https_header_b2045a7bfc.jpg
+tags: [""]
 ---
 
 If you're looking, you can find community all around you. Open source software development is no exception. By its nature, open source development is community-driven. People share and build on each other's work, making it better for all.

--- a/content/en/blog/posts/continuously-improving-covid-alert.md
+++ b/content/en/blog/posts/continuously-improving-covid-alert.md
@@ -15,6 +15,7 @@ image: https://de2an9clyit2x.cloudfront.net/improving_covid_alert_banner_6e181f5
 image-alt: Three people working to improve the COVID Alert application.
 translationKey: covid-alert-blog
 thumb: https://de2an9clyit2x.cloudfront.net/small_improving_covid_alert_banner_6e181f5c51.jpg
+tags: [""]
 ---
 <section class="page--outer-container-padding">
    <div class="row">

--- a/content/en/blog/posts/dear-colleagues-what-digital-training-do-you-need.md
+++ b/content/en/blog/posts/dear-colleagues-what-digital-training-do-you-need.md
@@ -12,6 +12,7 @@ image: https://de2an9clyit2x.cloudfront.net/screen_shot_2018_11_01_at_3_42_39_pm
 image-alt: A collection of work tools.
 translationKey: digital-training-needs
 thumb: https://de2an9clyit2x.cloudfront.net/small_screen_shot_2018_11_01_at_3_42_39_pm_a3ff96d004.jpg
+tags: [""]
 ---
 **Update:** *Building Digital Capacity: Report on the Training Needs Analysis is now available on Dalhousie University's website! [Read about what we heard here](/2019/08/30/assessing-government-training-needs-for-the-future-of-digital-service-delivery/). Thank you to all the public servants who took the survey. Your responses will help shape learning on emerging digital disciplines.*
 

--- a/content/en/blog/posts/designing-for-canada.md
+++ b/content/en/blog/posts/designing-for-canada.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_designing_for_canada_2017_a6cf2
 image-alt: 'Chris Govias, Chief of Design at CDS'
 translationKey: designing-for-canada
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_designing_for_canada_2017_a6cf251b7c.jpg
+tags: [""]
 ---
 After a short sabbatical and a decade in the U.K., I'm delighted to announce that I'm going to be the first Chief of Design with the Canadian Digital Service, a new initiative by the Government of Canada.
 

--- a/content/en/blog/posts/developing-an-evaluation-framework-for-product-and-service-delivery.md
+++ b/content/en/blog/posts/developing-an-evaluation-framework-for-product-and-service-delivery.md
@@ -14,6 +14,7 @@ image-alt: Four black empty picture frames hanging side by side on a white wall.
 translationKey: evaluation-framework
 thumb: https://de2an9clyit2x.cloudfront.net/small_four_frames_f2c06871f1.jpg
 
+tags: [""]
 ---
 If you're someone who follows or works with CDS you are probably interested in how we evaluate the success of our products and partnerships.
 

--- a/content/en/blog/posts/discovery-phase-understanding-the-problem.md
+++ b/content/en/blog/posts/discovery-phase-understanding-the-problem.md
@@ -16,6 +16,7 @@ image-alt: >-
   discussing their work.
 translationKey: discovery-phase-understanding-the-problem
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_discovery_16d2f21c99.jpg
+tags: [""]
 ---
 
 Veterans have dedicated their lives to serving Canada. Whether it’s RCMP or Canadian Armed Forces, leaving the service is like leaving a family and a job all at once. Veterans face many different challenges in this new phase of their life that are very different from the physical and psychological stresses they faced every day while wearing the uniform. One of the many major challenges is understanding and accessing the 20-plus benefits and services offered to them.

--- a/content/en/blog/posts/discussing-digital-in-french.md
+++ b/content/en/blog/posts/discussing-digital-in-french.md
@@ -14,6 +14,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_discussing_digital_in_french_20
 image-alt: Computer keyboard with the flag of France on a key
 translationKey: discussing-digital-in-french
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_discussing_digital_in_french_2017_0d1d34a4de.jpg
+tags: [""]
 ---
 Tomorrow, September 30, is International Translation Day. For me, talking about digital in French is a challenge: properly naming new technologies and *especially* - especially - not losing sight of the fact that we are addressing "real people". **Thinking of users first, making them central to our work - that also comes into play with the words that we choose**.
 

--- a/content/en/blog/posts/distance-makes-the-team-grow-stronger.md
+++ b/content/en/blog/posts/distance-makes-the-team-grow-stronger.md
@@ -13,6 +13,7 @@ image-alt: >-
   and in different locations.
 translationKey: distributed-pm
 thumb: https://de2an9clyit2x.cloudfront.net/small_distributed_pm_blog_c8f11db928.jpg
+tags: [""]
 ---
 It was a cold January day when I first started at The Canadian Digital Service (CDS). I went to the Ottawa office for a two-week onboarding session, after which I’d go back home to a *slightly warmer* Kitchener-Waterloo, to work full-time.
 

--- a/content/en/blog/posts/ear-to-the-ground-using-the-words-people-use.md
+++ b/content/en/blog/posts/ear-to-the-ground-using-the-words-people-use.md
@@ -16,6 +16,7 @@ image-alt: >-
 translationKey: using-words-people-use
 thumb: https://de2an9clyit2x.cloudfront.net/small_bag_and_hands_62d7b020be.jpg
 
+tags: [""]
 ---
 The way government talks can be quite different than how people outside of government talk. As a public servant, I know I’ve been guilty of using specialized language that loses meaning when it leaves the context of my team or department. I’ve also been on the other side, lost while trying to navigate a government website, or frustrated while trying to search different combinations of words, to find the right form.
 

--- a/content/en/blog/posts/empower-to-protect:-recalls-and-safety-alerts-in-canada.md
+++ b/content/en/blog/posts/empower-to-protect:-recalls-and-safety-alerts-in-canada.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/A_EN_Blog_Post_image_jpg_bdb43ff50e.
 image-alt: Photograph of Eric Chouinard, RSA Project Manager at Health Canada. They’re being featured in CDS’s "people behind the service" series.
 thumb: https://de2an9clyit2x.cloudfront.net/small_A_EN_Blog_Post_image_jpg_bdb43ff50e.jpg
 translationKey: blog-pbs-series-eric
+tags: [""]
 ---
 Did you hear about the [recent berries recall](https://recalls-rappels.canada.ca/en/alert-recall/below-zero-brand-whole-raspberries-iqf-recalled-due-norovirus)  or the [Kinder one in April](https://recalls-rappels.canada.ca/en/alert-recall/certain-kinder-brand-chocolate-products-recalled-due-possible-salmonella-0)?
 

--- a/content/en/blog/posts/eva’s-exit-interview-take-a-walk-on-the-private-side.md
+++ b/content/en/blog/posts/eva’s-exit-interview-take-a-walk-on-the-private-side.md
@@ -13,6 +13,7 @@ image-alt: >-
   animal crab wearing a shark hat.
 translationKey: take-a-walk-on-the-private-side
 thumb: https://de2an9clyit2x.cloudfront.net/small_eva_blog_6027e5f0f8.jpg
+tags: [""]
 ---
 One of our beloved developers and OG team member Eva Demers-Brett is leaving us this month to embark on an exciting opportunity in the private sector 😢. It’ll be her first time working outside the public service during her career as a developer, so we wanted to capture her insights and find out what lessons she’ll bring with her as she takes a walk on the private side.
 

--- a/content/en/blog/posts/explore-how-your-department-can-deliver-better-services.md
+++ b/content/en/blog/posts/explore-how-your-department-can-deliver-better-services.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/exporation_map_b1482d69bd.jpeg
 image-alt: Map full of digital symbols. In the centre, there is a laptop with a pair of binoculars looking out from the screen.
 thumb: https://de2an9clyit2x.cloudfront.net/small_exporation_map_b1482d69bd.jpeg
 translationKey: blog-questions-we-explore
+tags: [""]
 ---
 As we talked about in [Exploring the conditions for digital service delivery](https://digital.canada.ca/2021/04/07/exploring-the-conditions-for-digital-service-delivery/), we've learned that delivering better digital services is a lot like gardening. You can plant as many flowers as you want, but if the conditions aren’t suitable for growth, the seeds won’t sprout and your garden won’t thrive. 
 

--- a/content/en/blog/posts/exploring-the-conditions-for-digital-service-delivery.md
+++ b/content/en/blog/posts/exploring-the-conditions-for-digital-service-delivery.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/digital_gardeners_65c51a0b12.jpeg
 image-alt: A collection of flowers, leafs, and insects.
 thumb: https://de2an9clyit2x.cloudfront.net/small_digital_gardeners_65c51a0b12.jpeg
 translationKey: blog-digital-gardeners
+tags: [""]
 ---
 When I joined the Canadian Digital Service (CDS), I was excited to work with others to help the government deliver services differently. Previously, I had been on lots of teams and projects aiming to do new things in new ways to serve people better, with varying degrees of success and failure. I was eager to bring my government experience to CDS and help make a difference.   
 

--- a/content/en/blog/posts/framing-a-design-problem.md
+++ b/content/en/blog/posts/framing-a-design-problem.md
@@ -14,6 +14,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_framing_a_design_problem_2017_e
 image-alt: A room full of empty chairs at a citizenship ceremony
 translationKey: framing-a-design-problem
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_framing_a_design_problem_2017_ed45b772b5.jpg
+tags: [""]
 ---
 It’s an exciting time at the Canadian Digital Service (CDS) as we start rolling up our sleeves and digging into our first service delivery projects, while we are working hard on [choosing our next partnership opportunities](/2017/08/24/picking-our-projects/). One of our partners in these early projects is Immigration, Refugees and Citizenship Canada (IRCC).
 

--- a/content/en/blog/posts/from-build-first-to-users-first.md
+++ b/content/en/blog/posts/from-build-first-to-users-first.md
@@ -15,6 +15,7 @@ image-alt: >-
   blocks with a ladder and a group of people on top.
 translationKey: from-build-first-to-users-first
 thumb: https://de2an9clyit2x.cloudfront.net/small_fullsizeoutput_55_43eb2f1cba.jpg
+tags: [""]
 ---
 At the Canadian Digital Service (CDS), we are excited to be working with government departments to build better [services](https://digital.canada.ca/products/). We are also keen to share lessons we learn from these experiences to hopefully help folks with their own work.
 

--- a/content/en/blog/posts/from-design-to-development-working-across-disciplines-at-cds.md
+++ b/content/en/blog/posts/from-design-to-development-working-across-disciplines-at-cds.md
@@ -12,6 +12,7 @@ image-alt: >-
   waiting to cross the street.
 translationKey: working-across-disciplines
 thumb: https://de2an9clyit2x.cloudfront.net/small_yoel_j_gonzalez_304137_unsplash_64d7101ca1.jpeg
+tags: [""]
 ---
 I took Interactive Multimedia and Design in school, where I learned a solid foundation in both design and development. Professors said we’d likely end up working between these two disciplines, as a bridge. Towards the end of my program, I chose to focus primarily on design. I didn’t realize that, some short years later, I’d be learning how to code again.
 

--- a/content/en/blog/posts/gc-notify-has-reached-beta.md
+++ b/content/en/blog/posts/gc-notify-has-reached-beta.md
@@ -12,6 +12,7 @@ image: https://de2an9clyit2x.cloudfront.net/notify_blog_beta_banner_en_aa3b3491e
 image-alt: 'A laptop and phone showing the GC Notify home page in Beta. '
 translationKey: blog-notify-beta
 thumb: https://de2an9clyit2x.cloudfront.net/small_notify_blog_beta_banner_en_aa3b3491ed.jpg
+tags: [""]
 ---
 Since introducing the GC Notify tool in 2019, we’ve helped government departments send [over 8.8 million notifications](https://notification.canada.ca/activity). After developing a first version of the service and improving the ways it meets people’s needs, we’d like to announce that GC Notify has officially moved from the Alpha to Beta phase, meaning its more stable, reliable and secure than ever before. 
 

--- a/content/en/blog/posts/get-updates-on-covid-19-–-email-notification-service.md
+++ b/content/en/blog/posts/get-updates-on-covid-19-–-email-notification-service.md
@@ -13,6 +13,7 @@ image-alt: >-
   their phone.
 translationKey: blog-get-covid-updates
 thumb: https://de2an9clyit2x.cloudfront.net/small_financial_help_covid_19_en_135802d892.jpg
+tags: [""]
 ---
 **"Digital is about applying the culture, processes, business models and technologies of the internet era to respond to people's raised expectations." – Tom Loosemore**
 

--- a/content/en/blog/posts/getting-external-wi-fi-in-government-offices.md
+++ b/content/en/blog/posts/getting-external-wi-fi-in-government-offices.md
@@ -11,6 +11,7 @@ image: https://de2an9clyit2x.cloudfront.net/img_20190206_121320_bceaa8ad84.jpg
 image-alt: A person connecting their MacBook to a handheld MiFi device.
 translationKey: external-wifi
 thumb: https://de2an9clyit2x.cloudfront.net/small_img_20190206_121320_bceaa8ad84.jpg
+tags: [""]
 ---
 Having access to modern tools is a prerequisite for delivering modern digital services. We’ve written previously about [the importance of modern tools](https://digital.canada.ca/2018/06/27/tools-to-do-good-work/), like MacBooks and Linux-based laptops, for design and software development work.
 

--- a/content/en/blog/posts/getting-prototypes-out-the-door.md
+++ b/content/en/blog/posts/getting-prototypes-out-the-door.md
@@ -13,6 +13,7 @@ image-alt: >-
   e-briefing app.
 translationKey: getting-prototypes-out-the-door
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_ebriefing_2018_e3c77beee0.jpg
+tags: [""]
 ---
 
 Getting hands-on feedback from users is the best way to improve a digital product. All of the strategy meetings, planning, and requirements-gathering that are typical steps in developing software in government can’t compare to the experience of

--- a/content/en/blog/posts/getting-up-to-speed-on-an-agile-team.md
+++ b/content/en/blog/posts/getting-up-to-speed-on-an-agile-team.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_up_to_speed_030a3f5cc5.jpg
 image-alt: Car dashboard showing speedometer.
 translationKey: getting-up-to-speed
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_up_to_speed_030a3f5cc5.jpg
+tags: [""]
 ---
 
 Driving someone else's vehicle can sometimes feel a little off. Mirrors need to be adjusted, seats repositioned, gauges moved to your comfort zone. It's not your car, but you still have a general sense of where things should be and roughly how they should work. Joining a new team should be the same. Walking in, you should be able to get a sense of how things work fairly quickly.  Joining a new team shouldn’t feel like getting into a helicopter with no training and being asked to fly it.

--- a/content/en/blog/posts/global-skills-strategy.md
+++ b/content/en/blog/posts/global-skills-strategy.md
@@ -16,6 +16,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_global_skills_strategy_42ab3dc4
 image-alt: A woman in silver shoes standing on a subway platform.
 translationKey: global-skills-strategy
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_global_skills_strategy_42ab3dc4c1.jpg
+tags: [""]
 ---
 
 When I started at the Canadian Digital Service (CDS), I was expecting challenges and opportunities, but I hadn’t really thought about the new roads we’d travel to hire the best people. In this blog post, I’ll share our experiences of working with Immigration, Refugees, and Citizenship Canada (IRCC) to bring specialists from around the world into CDS. Specifically, how we used the new Global Skills Strategy to hire our first international team member.

--- a/content/en/blog/posts/growing-service-design-and-design-research-at-pspc.md
+++ b/content/en/blog/posts/growing-service-design-and-design-research-at-pspc.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/pspc_team_1_d45ef92076.jpg
 image-alt: A photo of PSPC’s Design Research team.
 translationKey: emilio-pspc
 thumb: https://de2an9clyit2x.cloudfront.net/small_pspc_team_1_d45ef92076.jpg
+tags: [""]
 ---
 When we talk about service design in government, the conversation is focused on creating amazing citizen-facing services. This is true to our core purpose - we work to serve citizens and therefore need to create services that put citizens at their core.
 

--- a/content/en/blog/posts/hello-world-canada.md
+++ b/content/en/blog/posts/hello-world-canada.md
@@ -11,6 +11,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_hello_world_canada_548cf9565c.j
 image-alt: Red maple leaves.
 translationKey: hello-world-canada
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_hello_world_canada_548cf9565c.jpg
+tags: [""]
 ---
 
 Hello! CDS is just over one year old, and having had the ~~honor~~ honour of serving with this team for six months now, I’m well overdue to write a few words here.

--- a/content/en/blog/posts/helping-low-income-canadians-complete-their-taxes.md
+++ b/content/en/blog/posts/helping-low-income-canadians-complete-their-taxes.md
@@ -13,6 +13,7 @@ image: https://de2an9clyit2x.cloudfront.net/img_0880_26a9215f41.jpg
 image-alt: Someone filling out taxes on paper and holding a mug.
 translationKey: Canadians-complete-taxes
 thumb: https://de2an9clyit2x.cloudfront.net/small_img_0880_26a9215f41.jpg
+tags: [""]
 ---
 Every day, Canadians use government services. As public servants, we exist to design and deliver those services. Many of those services are mission critical to people who need them. What this means is that when people need government services, they are often facing significant hardship.
 

--- a/content/en/blog/posts/helping-people-find-content:-how-to-build-a-website-search-bar.md
+++ b/content/en/blog/posts/helping-people-find-content:-how-to-build-a-website-search-bar.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_website_searchbar_0992ac5244.jp
 image-alt: Website search bar icon with text ‘Enter your search’.
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_website_searchbar_0992ac5244.jpg
 translationKey: blog-website-searchbar
+tags: [""]
 ---
 *Here's a friendly heads-up to our readers - this is NOT our usual type of post. We've got a technical look at how search functionality can be added to a website. Web Devs, this one's for you!*
 

--- a/content/en/blog/posts/hiring-at-cds.md
+++ b/content/en/blog/posts/hiring-at-cds.md
@@ -11,6 +11,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_hiring_2018_0d71687f48.jpg
 image-alt: Team members of CDS
 translationKey: hiring-at-cds
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_hiring_2018_0d71687f48.jpg
+tags: [""]
 ---
 There’s a lot of interest on how we are recruiting and staffing up a digital services team that can hit the ground running and help solve service challenges across the Government. This is why I am super excited to be writing a blog post about our hiring practices at CDS.
 

--- a/content/en/blog/posts/how-a-new-directive-makes-it-easier-to-procure-software-in-the-gc.md
+++ b/content/en/blog/posts/how-a-new-directive-makes-it-easier-to-procure-software-in-the-gc.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/procurement_directive_maze_9e6402d02
 image-alt: A straight line going straight through the middle of a confusing maze, leading to a signed document.
 thumb: https://de2an9clyit2x.cloudfront.net/small_procurement_directive_maze_9e6402d02b.jpeg
 translationKey: blog-figma-procurement
+tags: [""]
 ---
 ## TL;DR  _(too long; didn’t read)_
 

--- a/content/en/blog/posts/how-communications-and-data-can-live-happily-ever-after.md
+++ b/content/en/blog/posts/how-communications-and-data-can-live-happily-ever-after.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/dreaming_of_words_7126bfb389.jpg
 image-alt: Illustration of a girl daydreaming about writing and books.
 translationKey: Data-driven-comms
 thumb: https://de2an9clyit2x.cloudfront.net/small_dreaming_of_words_7126bfb389.jpg
+tags: [""]
 ---
 ## Once upon a time...
 

--- a/content/en/blog/posts/how-meeting-face-to-face-builds-team-trust.md
+++ b/content/en/blog/posts/how-meeting-face-to-face-builds-team-trust.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/groupvac_cds_593fa30b36.jpg
 image-alt: The team members all stand together and smile for a photo.
 translationKey: VAC-CDS-visit
 thumb: https://de2an9clyit2x.cloudfront.net/small_groupvac_cds_593fa30b36.jpg
+tags: [""]
 ---
 As a business analyst consulting at Veterans Affairs Canada (VAC) in Charlottetown partnered with the Canadian Digital Service, it’s been challenging to join an in-progress project when teams are located in different cities. Even with a daily remote standup, you don’t get to know who everybody is, and it’s hard to match a voice to a name when you’ve never met.
 

--- a/content/en/blog/posts/how-people-in-government-are-making-their-research-more-inclusive.md
+++ b/content/en/blog/posts/how-people-in-government-are-making-their-research-more-inclusive.md
@@ -12,6 +12,7 @@ image: https://de2an9clyit2x.cloudfront.net/inclusive_research_event_4cb5105cda.
 image-alt: People connecting over a virtual meeting to discuss work and new ideas.
 translationKey: inclusive-research-event
 thumb: https://de2an9clyit2x.cloudfront.net/small_inclusive_research_event_4cb5105cda.jpg
+tags: [""]
 ---
 Design researchers are responsible for advocating for people using government services. One of the biggest challenges we face is doing research that we feel represents the needs of *all* users - not just those who we think might fit neatly in the mainstream. Factors like race, ability, age, physical location, gender or digital literacy can put people at a distinct disadvantage when it comes to accessing government services.
 

--- a/content/en/blog/posts/how-running-an-ama-in-government-was-like-running-a-relay-race.md
+++ b/content/en/blog/posts/how-running-an-ama-in-government-was-like-running-a-relay-race.md
@@ -12,6 +12,7 @@ image: https://de2an9clyit2x.cloudfront.net/ama_banner_032dcb83f7.jpg
 image-alt: A bird’s-eye view of 4 relay racers running on a track in 4 parallel lanes.
 translationKey: relay-race-ama
 thumb: https://de2an9clyit2x.cloudfront.net/small_ama_banner_032dcb83f7.jpg
+tags: [""]
 ---
 Imagine this: you’re the starting runner in a 400m relay race. You get into the starting position, the gun goes off, and you sprint as hard as you can. As you reach that first 100m mark, you notice there’s no one to pass the baton to. Oh no. Now you have to sprint the whole relay race and keep the momentum going by yourself.
 

--- a/content/en/blog/posts/how-to-thoughtfully-name-government-services.md
+++ b/content/en/blog/posts/how-to-thoughtfully-name-government-services.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/banner_blog_naming_gov_services_3e99
 image-alt: The letters in the word service displayed on misplaced puzzle pieces. It shows how things don’t always fit together!
 thumb: https://de2an9clyit2x.cloudfront.net/small_banner_blog_naming_gov_services_3e9945e4af.jpeg
 translationKey: blog-naming-gov-services
+tags: [""]
 ---
 The words we use as public servants to name government services and programs are important. They shape people’s expectations. Think about it: those words — ideally, carefully chosen — show the people we serve that we can offer the right solutions and resources to meet their needs. When a name doesn’t fit, it’s confusing and can lead to misunderstandings.   
 

--- a/content/en/blog/posts/how-we-implemented-notify-on-canada-ca.md
+++ b/content/en/blog/posts/how-we-implemented-notify-on-canada-ca.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_service_canada_notify_227a13a00
 image-alt: Rainbow parachute in the sky.
 translationKey: blog-service-canada-notify
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_service_canada_notify_227a13a007.jpg
+tags: [""]
 ---
 [Canada.ca](https://www.canada.ca/en.html), the Government of Canada’s centralized website, is now using Notify for sending auto-reply emails for its [questions and comments form](https://www.canada.ca/en/contact/questions.html). These notifications reassure users that their form was successfully submitted to a trusted Canada.ca domain.
 

--- a/content/en/blog/posts/how-we-measured-our-delivery-with-vac-and-why-its-useful.md
+++ b/content/en/blog/posts/how-we-measured-our-delivery-with-vac-and-why-its-useful.md
@@ -11,6 +11,7 @@ image: https://de2an9clyit2x.cloudfront.net/VAC_Benchmark_Blog_ENG_e80e8464a0.jp
 image-alt: A screenshot of the tool *Find Benefits and services’* landing page.
 translationKey: by-the-numbers
 thumb: https://de2an9clyit2x.cloudfront.net/small_VAC_Benchmark_Blog_ENG_e80e8464a0.jpg
+tags: [""]
 ---
 If you measure it, you know if you're making it better. That's why at the Canadian Digital Service we like to have a measure of where we are before we start iterating. That way, we know how far we've come after improving a product or service.
 

--- a/content/en/blog/posts/how-we’re-trying-to-make-virtual-onboarding-better.md
+++ b/content/en/blog/posts/how-we’re-trying-to-make-virtual-onboarding-better.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/brady_bunch_fef4e4a9a9.jpeg
 image-alt: A video call grid with team members in different locations. They’re waving and interacting with each other.
 thumb: https://de2an9clyit2x.cloudfront.net/small_brady_bunch_fef4e4a9a9.jpeg
 translationKey: blog-virtual-onboarding
+tags: [""]
 ---
 When the pandemic started, life – and work life – changed overnight. For one thing, my commute to work got much shorter. (It’s approximately 8 seconds now.) There’s no more sitting in traffic or running to catch a train. And I definitely don’t miss ‘sardine-ing’ into the office elevators in the morning. Instead, I now make a quick stop at “Café Sana” and join the Talent team’s standup, fully rested and un-squished. 
 

--- a/content/en/blog/posts/human-story-behind-citizenship.md
+++ b/content/en/blog/posts/human-story-behind-citizenship.md
@@ -13,6 +13,7 @@ image-alt: >-
   Vancouver.
 translationKey: human-story-behind-citizenship
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_human_story_citizenship1_76d5a3f84e.jpg
+tags: [""]
 ---
 
 In government, we deliver services that meet fundamental human needs: for belonging, for safety, and for human connection. Becoming a citizen of a new country is one of the most emotional life experiences a person will go through and marks the completion of a long journey.

--- a/content/en/blog/posts/illustrating-with-diversity-and-inclusion-for-the-covid-alert-app.md
+++ b/content/en/blog/posts/illustrating-with-diversity-and-inclusion-for-the-covid-alert-app.md
@@ -14,6 +14,7 @@ image-alt: >-
   clothing, going about their day.
 translationKey: blog-illustrating-covid-alert
 thumb: https://de2an9clyit2x.cloudfront.net/small_banner_covid_alert_illustration_7da49c6dc3.jpg
+tags: [""]
 ---
 A healthcare app that reminds us of a particularly difficult time is not always going to be a comfortable experience to build - or to use.
 

--- a/content/en/blog/posts/improving-our-covid-19-benefits-finder-tool-using-a-feedback-text-box.md
+++ b/content/en/blog/posts/improving-our-covid-19-benefits-finder-tool-using-a-feedback-text-box.md
@@ -10,6 +10,7 @@ image-alt: >-
   usability from 8 different people.
 translationKey: blog-ffhc19-feedback
 thumb: https://de2an9clyit2x.cloudfront.net/small_adrianne_blog_en_8f917cc7df.jpg
+tags: [""]
 ---
 On May 7th, we soft launched the *[Find financial help during COVID-19](http://canada.ca/coronavirus-benefits)* online tool in partnership with Service Canada. The purpose of this co-developed tool is to help reduce financial stress that people in Canada are experiencing during the pandemic. By having people answer a few simple questions anonymously, the tool provides them with a tailored list of benefits for their specific situation. We included a feedback text box, which has had a huge impact on our ability to improve the tool with the help of the people using it every day.
 

--- a/content/en/blog/posts/in-this-together.md
+++ b/content/en/blog/posts/in-this-together.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_in_this_together_2017_082de0960
 image-alt: The Ontario Digital Service team
 translationKey: in-this-together
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_in_this_together_2017_082de0960c.jpg
+tags: [""]
 ---
 A few weeks ago, I had the chance to participate in the [Connected150 conference](http://www.connected150.ca) and spend some time with our colleagues in the Canadian Digital Service (CDS).
 

--- a/content/en/blog/posts/inclusive-workplace-language:-being-more-thoughtful-about-the-words-we-use.md
+++ b/content/en/blog/posts/inclusive-workplace-language:-being-more-thoughtful-about-the-words-we-use.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/word_bubbles_0d3d2006c1.jpg
 image-alt: Different coloured speech bubbles overlapping each other. 
 thumb: https://de2an9clyit2x.cloudfront.net/small_word_bubbles_0d3d2006c1.jpg
 translationKey: blog-inclusive-words
+tags: [""]
 ---
 Words matter. This is certainly true in service design. Here at the Canadian Digital Service (CDS), we try to use words that people use. It helps make the services we create more inclusive and easier to understand.
 

--- a/content/en/blog/posts/innovating-from-the-inside-out-at-esdc.md
+++ b/content/en/blog/posts/innovating-from-the-inside-out-at-esdc.md
@@ -15,6 +15,7 @@ image-alt: >-
   Slack and FunRetro” on a light blue background over a photo of the woods
 translationKey: innovating-esdc
 thumb: https://de2an9clyit2x.cloudfront.net/small_esdc_innovation_en_a0a320022b.jpg
+tags: [""]
 ---
 At Employment and Social Development Canada (ESDC), we’ve really started to embrace the idea of being innovative in how we provide services and information to our clients. What seems to be much harder, at times, is opening our doors internally to new and innovative ways of doing our day-to-day work.
 

--- a/content/en/blog/posts/intercept-testing-in-montreal.md
+++ b/content/en/blog/posts/intercept-testing-in-montreal.md
@@ -14,6 +14,7 @@ image: https://de2an9clyit2x.cloudfront.net/field_note_train_0fc028062b.jpg
 image-alt: 'A picture of the front of a train in an orange tinted background. '
 translationKey: field-note-1
 thumb: https://de2an9clyit2x.cloudfront.net/small_field_note_train_0fc028062b.jpg
+tags: [""]
 ---
 <p>Field Notes are a new content format for the Canadian Digital Service. Shorter than a blog post, a Field Note allows delivery teams to give more regular updates, share smaller insights and continue working in the open on a continuous basis.</p>
 

--- a/content/en/blog/posts/introducing-notify.md
+++ b/content/en/blog/posts/introducing-notify.md
@@ -13,6 +13,7 @@ image-alt: >-
   service homepage in English and French.
 translationKey: introducing-notify
 thumb: https://de2an9clyit2x.cloudfront.net/small_introducing_notify_d264bc51ad.jpg
+tags: [""]
 ---
 Imagine a scenario where every time you use a government service, all necessary information gets to where it’s going, when it needs to, and all along, you’re confident that it will. We’ve spent the past few months working to create a service that can help the Government of Canada meet this goal.
 

--- a/content/en/blog/posts/ircc-to-cds.md
+++ b/content/en/blog/posts/ircc-to-cds.md
@@ -13,6 +13,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_amir_7d10074bf1.jpg
 image-alt: Amir in the CDS workspace.
 translationKey: ircc-to-cds
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_amir_7d10074bf1.jpg
+tags: [""]
 ---
 
 I originally heard about CDS from my manager at IRCC, and, before you knew it, I was stalking their [GitHub repositories](https://github.com/cds-snc) and learning about a front-end library called [React](https://reactjs.org/). I was excited to get out of my silo and collaborate in what seemed to be an environment working with newer technologies.

--- a/content/en/blog/posts/its-about-people.md
+++ b/content/en/blog/posts/its-about-people.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_its_about_people_2017_0d56d9b4e
 image-alt: Anatole Papadopoulos speaking to some CDS staff
 translationKey: its-about-people
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_its_about_people_2017_0d56d9b4e9.jpg
+tags: [""]
 ---
 Putting users first. That’s what CDS is all about. When we talk about “digital government,” it often conjures up websites, APIs, and apps. They’re part of the toolkit. But digital government is about people: their needs, their experiences, their frustrations, even their hopes.
 

--- a/content/en/blog/posts/just-enough-detail-how-we-designed-content-for-the-covid-alert-app.md
+++ b/content/en/blog/posts/just-enough-detail-how-we-designed-content-for-the-covid-alert-app.md
@@ -12,6 +12,7 @@ image-alt: >-
   filter, there are 2 lines, now running in a straight line.
 translationKey: content-covidalert
 thumb: https://de2an9clyit2x.cloudfront.net/small_banner_content_covidalert_blog_198bc0a191.jpg
+tags: [""]
 ---
 When we first started work on [COVID Alert](https://www.canada.ca/en/public-health/services/diseases/coronavirus-disease-covid-19/covid-alert.html), [we knew one of the keys to success was trust](https://digital.canada.ca/2020/10/02/building-an-effective-exposure-notification-service-like-covid-alert/). People would not download the app if they didn’t trust it. And we knew that the key to trust was understanding.
 

--- a/content/en/blog/posts/language-gap.md
+++ b/content/en/blog/posts/language-gap.md
@@ -11,6 +11,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_language_gap_72a7c0e138.jpg
 image-alt: A French Poodle and an English Bulldog sitting in front of laptops.
 translationKey: language-gap
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_language_gap_72a7c0e138.jpg
+tags: [""]
 ---
 
 When choosing open source tools, one of the biggest obstacles we run into is language, or rather, a lack of the French language. Adapting an application to the local language is known as internationalisation, or [i18n](https://en.wikipedia.org/wiki/Internationalization_and_localization) for short. In Canada, we have the unique challenge of providing a robust, accessible experience in French and English, our official languages. Modern technologies are powerful, but the tech world is notoriously unilingual English. Many open source tools don’t provide the multilingual control we need, like the ability to swap to a version of the content in context. So how do we bridge this gap to deliver modern services to Canadians?

--- a/content/en/blog/posts/launch-of-the-canadian-digital-service.md
+++ b/content/en/blog/posts/launch-of-the-canadian-digital-service.md
@@ -13,6 +13,7 @@ image: https://de2an9clyit2x.cloudfront.net/launch_post_2017_f32b0ac0bf.jpg
 image-alt: 'The Honourable Scott Brison, President of the Treasury Board'
 translationKey: launch-of-the-canadian-digital-service
 thumb: https://de2an9clyit2x.cloudfront.net/small_launch_post_2017_f32b0ac0bf.jpg
+tags: [""]
 ---
 Canadians deserve government services that are easy to access and to use. They expect their government to be focused on service to citizens. In the connected world of the 21st century, good service means digital delivery, whether you are ordering take-out, rearranging your mortgage, managing your prescriptions -- or accessing government programs and services.
 

--- a/content/en/blog/posts/launching-an-alpha-service.md
+++ b/content/en/blog/posts/launching-an-alpha-service.md
@@ -15,6 +15,7 @@ image-alt: >-
   mobile phone.
 translationKey: get-updates-blog-2
 thumb: https://de2an9clyit2x.cloudfront.net/small_get_updates_c19_phone_en_211f956e6f.jpg
+tags: [""]
 ---
 *Marcel Saulnier and Jennifer Hollington are ADMs at Health Canada. Marcel oversaw the development and launch of the “[Get Updates on COVID-19](https://www.canada.ca/covid19updates)” email notification service as part of the COVID-19 Task Force. Jennifer’s communications team has taken over the service as it becomes part of Health Canada’s communications function.*
 

--- a/content/en/blog/posts/leading-by-example-a-sit-down-with-our-partner-at-the-rcmp.md
+++ b/content/en/blog/posts/leading-by-example-a-sit-down-with-our-partner-at-the-rcmp.md
@@ -15,6 +15,7 @@ image-alt: >-
   corners. It’s about taking a different path.”
 translationKey: jeff-adam-interview
 thumb: https://de2an9clyit2x.cloudfront.net/small_jeff_adam_9fda86899c.jpg
+tags: [""]
 ---
 In 1987, Jeff Adam joined the Royal Canadian Mounted Police (RCMP) because he wanted to help the vulnerable and catch the bad guys. Thirty-three years later, he’s still striving to do that, now as the Assistant Commissioner in charge of Technical Operations.
 

--- a/content/en/blog/posts/learning-from-the-people-who-want-to-use-our-reporting-service-but-might-not-use-it-now.md
+++ b/content/en/blog/posts/learning-from-the-people-who-want-to-use-our-reporting-service-but-might-not-use-it-now.md
@@ -17,6 +17,7 @@ image-alt: >-
 translationKey: reporting-service-checklist
 thumb: https://de2an9clyit2x.cloudfront.net/small_rcmp_prototype_en_7440cea621.jpg
 
+tags: [""]
 ---
 Our raison d’être at the Canadian Digital Service (CDS) is putting people first in order to make government services easier for them to use. So naturally, to help us better understand how we can do that, we talk a lot about conducting research with people who use our services.
 

--- a/content/en/blog/posts/learning-to-make-twitter-content-more-accessible.md
+++ b/content/en/blog/posts/learning-to-make-twitter-content-more-accessible.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/accessibility_tweets_blog_banner_650
 image-alt: A person using screen reading technology with their phone.
 thumb: https://de2an9clyit2x.cloudfront.net/small_accessibility_tweets_blog_banner_650f003408.jpg
 translationKey: blog-accessible-tweets
+tags: [""]
 ---
 No one likes to be excluded or have their needs and feelings not considered. At least, I know I sure don’t.
 

--- a/content/en/blog/posts/lets-talk-user-experience.md
+++ b/content/en/blog/posts/lets-talk-user-experience.md
@@ -14,6 +14,7 @@ image-alt: >-
   on the wall.
 translationKey: lets-talk-user-experience
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_user_experience_ab66691a2a.jpg
+tags: [""]
 ---
 
 <img width="100%" alt="Pixel evolving into a person — There are five shapes, starting with a square (pixel) on the left-hand side, eventually morphing into a full human figure on the right-hand side." src="https://de2an9clyit2x.cloudfront.net/ux_drawing_f80da5fb67.jpg">

--- a/content/en/blog/posts/lexicon.md
+++ b/content/en/blog/posts/lexicon.md
@@ -12,6 +12,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_lexicon_8af48d9cd5.jpg
 image-alt: Illustration a front-loading washer-dryer combo.
 translationKey: lexicon
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_lexicon_8af48d9cd5.jpg
+tags: [""]
 ---
 
 ## Why a lexicon?

--- a/content/en/blog/posts/little-and-often:-making-critique-a-daily-practice.md
+++ b/content/en/blog/posts/little-and-often:-making-critique-a-daily-practice.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/15_minutes_meetings_91e0181bab.jpg
 image-alt: A group of 7 people meeting virtually for 15 minutes.
 thumb: https://de2an9clyit2x.cloudfront.net/small_15_minutes_meetings_91e0181bab.jpg
 translationKey: blog-content-critiques
+tags: [""]
 ---
 Team critiques are a known best practice for content designers. But we struggled with precisely how to implement them at the Canadian Digital Service (CDS). For a long time we had a daily optional time slot in our calendars that anyone could use any time. But since anybody’s job is nobody’s job, we almost never actually had critique. So late last fall we made a new plan, which we started in January.   
 

--- a/content/en/blog/posts/making-a-great-first-impression-onboarding-matters.md
+++ b/content/en/blog/posts/making-a-great-first-impression-onboarding-matters.md
@@ -15,6 +15,7 @@ image-alt: >-
   notes. The desk is covered in stickers, chocolates and confetti.
 translationKey: onboarding-matters
 thumb: https://de2an9clyit2x.cloudfront.net/small_onboarding_banner_fitted_12c3d9a91b.jpg
+tags: [""]
 ---
 As a growing organization, we onboard new employees almost every week. While this is something we do regularly, it’s a once in a lifetime experience for the employee starting. A new job can be stressful, and the decision to stick with a job or move on is often made within the first few days. It’s vital that we create a great onboarding experience. We never want to lose sight of the fact that people are at the heart of what we do.
 

--- a/content/en/blog/posts/making-information-easy-to-see-and-hear-1.md
+++ b/content/en/blog/posts/making-information-easy-to-see-and-hear-1.md
@@ -15,6 +15,7 @@ image-alt: >-
   computer.
 translationKey: blog-screenreader-stuff
 thumb: https://de2an9clyit2x.cloudfront.net/small_screenreader_blog_banner_5e9a928d1d.jpg
+tags: [""]
 ---
 ## COVID Alert and backup codes
 

--- a/content/en/blog/posts/measuring-the-impact-of-covid-alert-with-metrics.md
+++ b/content/en/blog/posts/measuring-the-impact-of-covid-alert-with-metrics.md
@@ -14,6 +14,7 @@ image: https://de2an9clyit2x.cloudfront.net/metrics_covid_alert_blog_banner_d83e
 image-alt: Phones with multiple groupings of tally marks above them.
 translationKey: blog-metrics-app
 thumb: https://de2an9clyit2x.cloudfront.net/small_metrics_covid_alert_blog_banner_d83e1f15da.jpg
+tags: [""]
 ---
 Change is the only constant, especially when it comes to a pandemic. Like most are experiencing, I’ve had to get used to a bit of a different lifestyle – going from listening to obscure bands in eclectic spots across the GTA, to settling down with a Margaret Atwood novel. My Saturdays look very different.
 

--- a/content/en/blog/posts/meeting-the-needs-of-healthcare-authorities-to-roll-out-covid-alert-across-canada.md
+++ b/content/en/blog/posts/meeting-the-needs-of-healthcare-authorities-to-roll-out-covid-alert-across-canada.md
@@ -16,6 +16,7 @@ image-alt: >-
   and territories.
 translationKey: healthcare-portal-service-design
 thumb: https://de2an9clyit2x.cloudfront.net/small_app_portal_blog_banner_dddd52ec15.jpg
+tags: [""]
 ---
 [COVID Alert](https://www.canada.ca/en/public-health/services/diseases/coronavirus-disease-covid-19/covid-alert.html), the free Government of Canada exposure notification app for COVID-19, has been downloaded by over 2 million people. While the app itself is the public-facing touchpoint, there are things going on behind the scenes that enable it to do what it’s designed to do.
 

--- a/content/en/blog/posts/mixing-our-methods-how-we-improved-usability-with-qualitative-and-quantitative-design-research.md
+++ b/content/en/blog/posts/mixing-our-methods-how-we-improved-usability-with-qualitative-and-quantitative-design-research.md
@@ -17,6 +17,7 @@ image: https://de2an9clyit2x.cloudfront.net/mixed_methods_rcmp_9491d5f5b1.jpg
 image-alt: Two people consulting charts and graphs to help them make informed decisions.
 translationKey: rcmp-mixed-method
 thumb: https://de2an9clyit2x.cloudfront.net/small_mixed_methods_rcmp_9491d5f5b1.jpg
+tags: [""]
 ---
 
 There’s risk involved with doing something new in every industry. So when we come to the table with new methods to deliver digital services in government, we understand why our partners in the public service are cautious or even hesitant to jump on board right away.

--- a/content/en/blog/posts/moving-content-from-code-to-cloud.md
+++ b/content/en/blog/posts/moving-content-from-code-to-cloud.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/magnificent_cloud_ac2e627c55.jpg
 image-alt: A magnificent cloud rises above the trees.
 translationKey: from-code-to-cloud
 thumb: https://de2an9clyit2x.cloudfront.net/small_magnificent_cloud_ac2e627c55.jpg
+tags: [""]
 ---
 At CDS, we’re currently working on a [web app](https://github.com/cds-snc/vac-benefits-directory) with Veterans Affairs Canada (VAC). The app will help Veterans and their families find benefits and programs that are relevant to them. That means it needs to keep track of a lot of content: the user interface (UI) text, titles and one-line descriptions of the benefits, multiple choice questions, tags associated with the benefits, VAC office addresses, and more, none of which was personal data or information. And, of course, all this text is in English and French.
 

--- a/content/en/blog/posts/moving-fast-staying-safe:-being-‘agile’-in-government.md
+++ b/content/en/blog/posts/moving-fast-staying-safe:-being-‘agile’-in-government.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/banner_blog_fast_safe_agile_b003ff8c
 image-alt: Two protective helmets – a motorcycle helmet showing “move fast” and a hard hat for construction showing “stay safe.”
 thumb: https://de2an9clyit2x.cloudfront.net/small_banner_blog_fast_safe_agile_b003ff8c43.jpg
 translationKey: blog-fast-safe-agile
+tags: [""]
 ---
 It’s a great time to be working in digital service delivery. People are more connected than ever expecting to have access to modern digital services. At the same time, “agile” development — building and testing prototypes in weeks rather than spending years in planning — has gained mainstream acceptance. 
 

--- a/content/en/blog/posts/multiplayer-mode-unlocked-better-team-collaboration-for-designers-developers-and-researchers.md
+++ b/content/en/blog/posts/multiplayer-mode-unlocked-better-team-collaboration-for-designers-developers-and-researchers.md
@@ -16,6 +16,7 @@ image-alt: >-
   court together.
 translationKey: multiplayer-figma
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_multiplayer_figma_4b3304945a.jpg
+tags: [""]
 ---
 Many games are more fun to play in multiplayer mode than in single player. Can you imagine playing a game of basketball by yourself? Boring.
 

--- a/content/en/blog/posts/our-partnership-with-code-for-canada.md
+++ b/content/en/blog/posts/our-partnership-with-code-for-canada.md
@@ -12,6 +12,7 @@ image-alt: >-
   provincial parliament building in Toronto.
 translationKey: our-partnership-with-code-for-canada
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_c4c_26d807bbf1.jpg
+tags: [""]
 ---
 
 This past fall, we brought on one of the first two cohorts of [Code for Canada](https://codefor.ca/) (C4C) fellows, the other joining our colleagues in the Government of Ontario. This post outlines how to make the most out of a potential partnership!

--- a/content/en/blog/posts/picking-our-projects.md
+++ b/content/en/blog/posts/picking-our-projects.md
@@ -14,6 +14,7 @@ image: https://de2an9clyit2x.cloudfront.net/picking_our_projects_2017_b3fdfe5d6f
 image-alt: Posters in the CDS office
 translationKey: picking-our-projects
 thumb: https://de2an9clyit2x.cloudfront.net/small_picking_our_projects_2017_b3fdfe5d6f.jpg
+tags: [""]
 ---
 I grew up on a farm. It was a childhood marked by the feeling of gravel beneath my feet, dirt on my hands, and the joy of picking produce right from the field. I wish I could tell you that picking projects is the same but I have yet to encounter gravel, dirt or produce during a partnership chat (bonus points if you make this happen!)
 

--- a/content/en/blog/posts/pivoting-how-we-partner.md
+++ b/content/en/blog/posts/pivoting-how-we-partner.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/banner_pivoting_partnerships_d296e0d
 image-alt: An interconnected web showing people across Canada working together to provide digital services. They put people at the heart of their work.
 thumb: https://de2an9clyit2x.cloudfront.net/small_banner_pivoting_partnerships_d296e0dc14.jpg
 translationKey: blog-pivoting-partnerships
+tags: [""]
 ---
 Five years ago, we announced the [launch of the Canadian Digital Service](https://digital.canada.ca/2017/07/18/launch-of-the-canadian-digital-service/) (CDS), as a three year-pilot project to help modernize the way the Government of Canada designs and delivers digital services. Since then, we’ve learned and [grown a lot](https://digital.canada.ca/meet-the-team/). Last year, we secured ongoing funding through Budget 2021, so we can continue to partner with government teams and offer government-wide services like [GC Notify](https://notification.canada.ca/), with the confidence that we will be around to maintain and improve them.
 

--- a/content/en/blog/posts/policy.md
+++ b/content/en/blog/posts/policy.md
@@ -15,6 +15,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_puzzle_19c62eec59.jpg
 image-alt: Puzzle pieces of different colours connected together.
 translationKey: policy
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_puzzle_19c62eec59.jpg
+tags: [""]
 ---
 Here at the Canadian Digital Service, we've been lucky to have great role models to learn from, in the U.K., the U.S., Italy, Australia, Ontario, and many other places, as we work with our partners to improve digital services for Canadians. We use a well-established play to help drive this mission: bringing together multidisciplinary talent into teams that tackle a service challenge together. Our product teams include designers, researchers, developers and product managers, but we've also embedded policy and communications people into those teams.
 

--- a/content/en/blog/posts/product-teams-brainstorming-during-ideation-week-this-might-be-a-terrible-idea-but-….md
+++ b/content/en/blog/posts/product-teams-brainstorming-during-ideation-week-this-might-be-a-terrible-idea-but-….md
@@ -13,6 +13,7 @@ image: https://de2an9clyit2x.cloudfront.net/ideas_7f6ab400e5.jpg
 image-alt: CPP-D product team members looking up at lightbulbs drawn above their heads.
 translationKey: brainstorming-ideation-week
 thumb: https://de2an9clyit2x.cloudfront.net/small_ideas_7f6ab400e5.jpg
+tags: [""]
 ---
 Imagine standing up in front of your team at work and saying the worst possible idea you’ve ever had. Did that make you feel uncomfortable? We’ve been conditioned to bring only our very best ideas forward, but voicing the worst possible ideas is exactly what I asked my team to do during our recent Ideation week. Let me explain why this “outlandish” exercise was actually a very good idea.
 

--- a/content/en/blog/posts/productive-collaboration.md
+++ b/content/en/blog/posts/productive-collaboration.md
@@ -18,6 +18,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_productive_collaboration_b08bf0
 image-alt: The product team gathers around the sprint board at a daily standup meeting.
 translationKey: productive-collaboration
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_productive_collaboration_b08bf045d4.jpg
+tags: [""]
 ---
 
 At CDS, we build our product teams to consist of product managers, researchers, designers, developers, policy experts, and communication specialists. But, assembling a multidisciplinary team does not mean the hardest part is done. All of the individuals that you’ve gathered onto your team come from different disciplines and they each have their own preferred ways of working. This includes (but is not limited to) the pace, tools, hours, times of day, environmental conditions, communication methods, and the ways each person prefers to give and receive feedback. With so many different variables, it’s easy for things to quickly get overwhelming.

--- a/content/en/blog/posts/putting-your-trust-in-humans…-and-robots.md
+++ b/content/en/blog/posts/putting-your-trust-in-humans…-and-robots.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/grass_lawn_robot_ee4fa0e7f5.jpg
 image-alt: 'A small wooden robot stands in a grassy green lawn. '
 translationKey: trust-humans-and-robots
 thumb: https://de2an9clyit2x.cloudfront.net/small_grass_lawn_robot_ee4fa0e7f5.jpg
+tags: [""]
 ---
 Effective product development and service delivery is nothing without trust. As a delivery team at CDS, we often speak to our partners about extending us the trust to help them leave their comfort zones and try new approaches.
 

--- a/content/en/blog/posts/qualitative-data-uncomfortable-but-worth-it.md
+++ b/content/en/blog/posts/qualitative-data-uncomfortable-but-worth-it.md
@@ -12,6 +12,7 @@ image-alt: >-
   reviewing a service diagram made up of different coloured sticky notes.
 translationKey: data-driven-service
 thumb: https://de2an9clyit2x.cloudfront.net/small_rcmp_data_blog_97a57c658d.jpg
+tags: [""]
 ---
 
 I’m an avid reader. I love books. But sometimes I struggle to choose which ones to read.

--- a/content/en/blog/posts/recruiting-our-ceo.md
+++ b/content/en/blog/posts/recruiting-our-ceo.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_ceo_recruitment_883dc9d347.jpg
 image-alt: Chief Executive Officer Aaron Snow chatting with two other team members.
 translationKey: recruiting-our-ceo
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_ceo_recruitment_883dc9d347.jpg
+tags: [""]
 ---
 
 We recently [announced](https://digital.canada.ca/2018/03/09/cds-gets-its-first-ceo/) that Aaron Snow is joining CDS as our first CEO. I’m delighted that Aaron is taking the leap to move to Ottawa and be part of our digital movement.

--- a/content/en/blog/posts/reducing-risk-through-continuous-deployment.md
+++ b/content/en/blog/posts/reducing-risk-through-continuous-deployment.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_continuous_deployment_69684377e
 image-alt: A man works at his desk working on code.
 translationKey: reducing-risk-through-continuous-deployment
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_continuous_deployment_69684377ec.jpg
+tags: [""]
 ---
 
 Most of the departments we work with are deploying new versions of their code quarterly, semi-annually, or annually. This fits well with the standard [waterfall software development](https://en.wikipedia.org/wiki/Waterfall_model) process, but it comes with some serious risks.

--- a/content/en/blog/posts/reflecting-on-what-i-learned-from-working-on-design-research-operations.md
+++ b/content/en/blog/posts/reflecting-on-what-i-learned-from-working-on-design-research-operations.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/anne_marie_blog_banner_b51d016be3.jp
 image-alt: A person looking at their reflection, seeing their accomplishments and how it’s formed them into the person they are.
 thumb: https://de2an9clyit2x.cloudfront.net/small_anne_marie_blog_banner_b51d016be3.jpg
 translationKey: blog-design-research-ops
+tags: [""]
 ---
 Most of us know that work often ends up including more than the job description outlined. Our values and personality, the relationships we build, and the way we approach our work  ultimately influence the impact we have and the direction a role can take.
 

--- a/content/en/blog/posts/reflections-on-a-service-at-100-weeks.md
+++ b/content/en/blog/posts/reflections-on-a-service-at-100-weeks.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/banner_100_weeks_get_updates_en_9568
 image-alt: A person researching GC Notify on their laptop and chatting on the phone with their manager about the tool.
 thumb: https://de2an9clyit2x.cloudfront.net/small_banner_100_weeks_get_updates_en_9568124f34.jpg
 translationKey: blog-100-weeks-get-updates
+tags: [""]
 ---
 March 7th, 2022 marked 100 weeks of providing people in Canada with reliable, needs-based information through the [Get updates on COVID-19](https://www.canada.ca/covid19updates) service. We’ve crossed many significant milestones along the way: 8.5 million emails sent, 364 000 Canada.ca visits from our emails, and over 100 000 online service subscriptions.
 

--- a/content/en/blog/posts/reschedule-a-citizenship-appointment.md
+++ b/content/en/blog/posts/reschedule-a-citizenship-appointment.md
@@ -15,6 +15,7 @@ image-alt: >-
   service counter.
 translationKey: reschedule-a-citizenship-appointment
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_ircc_april_9f8d1d0bfb.jpg
+tags: [""]
 ---
 
 The goal of our partnership with [Immigration, Refugees and Citizenship Canada](https://www.canada.ca/en/immigration-refugees-citizenship.html) (IRCC) is to make the process of rescheduling a citizenship appointment as convenient and stress-free as possible for applicants, whilst empowering frontline staff.

--- a/content/en/blog/posts/retrospective-on-energuide-api.md
+++ b/content/en/blog/posts/retrospective-on-energuide-api.md
@@ -13,6 +13,7 @@ image-alt: >-
   whiteboard.
 translationKey: retrospective-on-energuide-api
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_energuide_retro_f4780d2e1d.jpg
+tags: [""]
 ---
 
 As our partnership with NRCan on the EnerGuide API winds down, the CDS product team held a retrospective to reflect on our experience, accomplishments and lessons learned.

--- a/content/en/blog/posts/rfp.md
+++ b/content/en/blog/posts/rfp.md
@@ -11,6 +11,7 @@ image: https://de2an9clyit2x.cloudfront.net/rfp_eng_f9ec7032b9.jpg
 image-alt: 'A maple leaf sticker with the words, Strong and Free.'
 translationKey: rfp
 thumb: https://de2an9clyit2x.cloudfront.net/small_rfp_eng_f9ec7032b9.jpg
+tags: [""]
 ---
 
 Today we (the Canadian Digital Service) launched a [Request for Proposals](https://buyandsell.gc.ca/procurement-data/tender-notice/PW-18-00841347) (RFP).

--- a/content/en/blog/posts/running-inclusive-retros:-10-tips-for-growing-as-a-team!.md
+++ b/content/en/blog/posts/running-inclusive-retros:-10-tips-for-growing-as-a-team!.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/en_banner_blog_retro_facilitation_ti
 image-alt: A retro activity board outline with plants growing out of it. 
 thumb: https://de2an9clyit2x.cloudfront.net/small_en_banner_blog_retro_facilitation_tips_1cf0d3e501.jpg
 translationKey: blog-retro-facilitation-tips
+tags: [""]
 ---
 Do you ever run retros with your team? 
 

--- a/content/en/blog/posts/scaling-design-research-in-the-government-of-canada.md
+++ b/content/en/blog/posts/scaling-design-research-in-the-government-of-canada.md
@@ -15,6 +15,7 @@ image-alt: >-
   individual’s hand holding a unique red puzzle piece.
 translationKey: design-research
 thumb: https://de2an9clyit2x.cloudfront.net/small_puzzle_f193470c2c.jpg
+tags: [""]
 ---
 Design research (or user research) helps us understand the people who use our services. If we understand them, we can better meet their needs. We’ve seen how important design research is to delivering people-centered digital services in our work with partners. We’ve also seen how easily it can become mistaken for public opinion research (POR.)
 

--- a/content/en/blog/posts/scaling-inclusive-environments-begins-with-community-building-we-created-an-accessibility-handbook-to-help-you-get-started.md
+++ b/content/en/blog/posts/scaling-inclusive-environments-begins-with-community-building-we-created-an-accessibility-handbook-to-help-you-get-started.md
@@ -16,6 +16,7 @@ image-alt: >-
   standing in front of a purple wall.
 translationKey: accessibility-handbook
 thumb: https://de2an9clyit2x.cloudfront.net/small_accessibility_handbook_blog_00d02c5777.jpg
+tags: [""]
 ---
 Ten! Ten years, that’s how long I’ve worked in accessibility within the public service. I’ve watched the community grow and change as new faces have come and gone. Many people involved in accessibility in the public service when I first started out are still spearheading the charge today. We are a small, but mighty community, crossing departments and sectors to help improve access to services for people.
 

--- a/content/en/blog/posts/security-is-hard-it’s-also-necessary-and-manageable.md
+++ b/content/en/blog/posts/security-is-hard-it’s-also-necessary-and-manageable.md
@@ -8,6 +8,7 @@ image: https://de2an9clyit2x.cloudfront.net/airplane_460f30dd8a.jpg
 image-alt: An airplane taking off on a runway at dusk.
 translationKey: security-hard
 thumb: https://de2an9clyit2x.cloudfront.net/small_airplane_460f30dd8a.jpg
+tags: [""]
 ---
 Digital security is hard. Even the best engineering and IT teams are prone to make mistakes at some point. But like airport security, steps and processes along the way keep you safe and secure.
 

--- a/content/en/blog/posts/service-design-thats-our-jam.md
+++ b/content/en/blog/posts/service-design-thats-our-jam.md
@@ -14,6 +14,7 @@ image-alt: >-
   their heads.
 translationKey: service-design-thats-our-jam
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_jam_header_123dc590b3.jpg
+tags: [""]
 ---
 
 On June 21, the Canadian Digital Service (CDS) hosted its very first [Design Jam](https://www.youtube.com/watch?v=S_XeFWoR9uU) with 30 participants from the Canada Revenue Agency (CRA) & Employment and Social Development Canada (ESDC). With help from design mentors, participants brainstormed ideas to tackle current service challenges in the Government of Canada.

--- a/content/en/blog/posts/setting-users-up for-success-with-content-design.md
+++ b/content/en/blog/posts/setting-users-up for-success-with-content-design.md
@@ -14,6 +14,7 @@ description: >-
   empowering office staff.
 translationKey: setting-users-up-for-success-with-content-design
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_setting_up_users_for_success_0ab67b7ff1.jpg
+tags: [""]
 ---
 
 

--- a/content/en/blog/posts/showing-the-whole-iceberg.md
+++ b/content/en/blog/posts/showing-the-whole-iceberg.md
@@ -13,6 +13,7 @@ image-alt: >-
   aquarium while a small dog watches.
 translationKey: showing-the-whole-iceberg
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_iceberg_header_9690f17788.jpg
+tags: [""]
 ---
 
 *“I believe offices like CDS are change management offices disguised as digital service offices.”* - Aaron Snow, CEO

--- a/content/en/blog/posts/small-acts-big-impacts.md
+++ b/content/en/blog/posts/small-acts-big-impacts.md
@@ -12,6 +12,7 @@ image-alt: >-
   front of event attendees.
 translationKey: small-acts-big-impact
 thumb: https://de2an9clyit2x.cloudfront.net/small_diversity_day_banner_image_2_db8aa75931.jpg
+tags: [""]
 ---
 Diverse and inclusive teams deliver diverse and inclusive services. That’s why on Friday, February 8, The Canadian Digital Service hosted [Diversity in Digital Services](https://www.eventbrite.ca/e/diversity-in-digital-services-diversite-au-sein-des-services-numeriques-registration-51465629082), a day to brainstorm ideas around team diversity, inclusion, and their impact on delivering better services.
 

--- a/content/en/blog/posts/so-what-exactly-is-a-product-manager-anyway.md
+++ b/content/en/blog/posts/so-what-exactly-is-a-product-manager-anyway.md
@@ -15,6 +15,7 @@ image-alt: >-
   Montreal, Waterloo, Toronto, and Ottawa.
 translationKey: product-manager-QA
 thumb: https://de2an9clyit2x.cloudfront.net/small_pm_banner_fix_646dadacee.jpg
+tags: [""]
 ---
 If you find yourself speaking to someone who is highly organized, curious, adaptive, communicative, empathetic, and passionate about removing barriers in order to get stuff done, chances are you’re either talking to a superhuman or a product manager.
 

--- a/content/en/blog/posts/striving-for-diversity.md
+++ b/content/en/blog/posts/striving-for-diversity.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_striving_for_diversity_7cb58475
 image-alt: A blue ribbon banner with the words “a mari usque ad mare” in yellow.
 translationKey: striving-for-diversity
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_striving_for_diversity_7cb58475fa.jpg
+tags: [""]
 ---
 
 One of the biggest perks of working for the Canadian Digital Service (CDS) is that we have the opportunity to serve Canadians every day. Public servants work to make positive impacts on people all across Canada. In fact, Canada’s motto is *A Mari Usque Ad Mare*, which translates to *From Sea to Sea*, and that’s the truth. That said, from sea to sea implicates a lot of people. Indigenous people, immigrants, refugees, and families who have been here for generations. People of all cultures, races, religions, identities, and backgrounds. How can we serve all of these groups with equality and equity? For starters, we can build teams as diverse as the people we serve.

--- a/content/en/blog/posts/supporting-users-gracefully-degrading-react.md
+++ b/content/en/blog/posts/supporting-users-gracefully-degrading-react.md
@@ -15,6 +15,7 @@ image-alt: >-
   a flip phone, a laptop and a computer tower.
 translationKey: supporting-users-gracefully-degrading-react
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_no_JS_16ec4cec0b.jpg
+tags: [""]
 ---
 
 Using modern technologies can make development faster, but ultimately we need to deliver working solutions without sacrificing robustness or accessibility. We’ve built the “Reschedule a citizenship test” service in a way that pushes service delivery forward without leaving users behind.

--- a/content/en/blog/posts/teaming-up-to-deliver-better-outcomes-for-veterans.md
+++ b/content/en/blog/posts/teaming-up-to-deliver-better-outcomes-for-veterans.md
@@ -11,6 +11,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_pei_banner_b2696e820b.jpg
 image-alt: A red sanded clif overlooking the sea in Prince Edward Island.
 translationKey: teaming-up-to-deliver-better-outcomes-for-veterans
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_pei_banner_b2696e820b.jpg
+tags: [""]
 ---
 
 Recently a small contingent from CDS was lucky enough to visit Prince Edward Island off Canada’s Maritime coast. We were there at the invitation of [Veterans Affairs Canada](http://www.veterans.gc.ca/) (VAC), who we're working with to improve how Veterans find benefits online.

--- a/content/en/blog/posts/technology-choices-at-cds.md
+++ b/content/en/blog/posts/technology-choices-at-cds.md
@@ -16,6 +16,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_technology_choices_at_cds_2017_
 image-alt: A computer screen showing results from a test suite
 translationKey: technology-choices-at-cds
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_technology_choices_at_cds_2017_7fc41ef768.jpg
+tags: [""]
 ---
 A few weeks ago, we opened our [public recruitment campaign](/careers/), looking for designers, developers, data scientists, product managers, and engagement experts. On the developer stream, a number of people have reached out to ask which technology platforms and programming languages we work in. It’s a great question! One of the exciting parts of joining CDS at such an early stage in our existence is that you’ll have a chance to shape how our technology choices evolve. With that in mind – none of these are set in stone – I thought I’d share the current thinking of our developer team, and the two (competing) goals that influence the technologies we choose.
 

--- a/content/en/blog/posts/testing-assumptions-before-fixing-problems.md
+++ b/content/en/blog/posts/testing-assumptions-before-fixing-problems.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_banner_testing_security_assumpt
 image-alt: A person brainstorming questions and then investigating those questions deeper, before trying to fix and find answers for them.
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_banner_testing_security_assumptions_946d799a9a.jpeg
 translationKey: blog-testing-security-assumptions
+tags: [""]
 ---
 Is solving a problem that doesn’t actually exist, really solving a problem? When we work off of assumptions – and don’t test them – we may be doing just that. 
 

--- a/content/en/blog/posts/the-best-panic-attack-i-ever-had.md
+++ b/content/en/blog/posts/the-best-panic-attack-i-ever-had.md
@@ -13,6 +13,7 @@ image-alt: >-
   attack.
 translationKey: best-panic-attack
 thumb: https://de2an9clyit2x.cloudfront.net/small_montreal_library_ec52e16559.jpg
+tags: [""]
 ---
 Exactly one year ago, I was having a panic attack in the restroom of a public library in Montreal.
 

--- a/content/en/blog/posts/the-good-the-bad-and-the-struggle-a-recap-of-cds-distributed-week.md
+++ b/content/en/blog/posts/the-good-the-bad-and-the-struggle-a-recap-of-cds-distributed-week.md
@@ -12,6 +12,7 @@ image-alt: >-
   at home.
 translationKey: CDS-distributed
 thumb: https://de2an9clyit2x.cloudfront.net/small_google_hangout_9039889404.jpg
+tags: [""]
 ---
 Over the past year, the Canadian Digital Service (CDS) has grown considerably with colleagues in Ottawa, Toronto, Montreal, and Kitchener-Waterloo. Though our Ottawa office has the most amount of people, we’re a distributed organization. That means we work in an environment where everyone, regardless of geographic location, is able to fully contribute to team goals the same way that a team all working out of the same office can.
 

--- a/content/en/blog/posts/the-policy-pieces-for-conducting-research-with-vac.md
+++ b/content/en/blog/posts/the-policy-pieces-for-conducting-research-with-vac.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/tim_swaan_45717_unsplash_e218e3ac92.
 image-alt: footbridge-leading-towards-forest
 translationKey: user-interview-policy
 thumb: https://de2an9clyit2x.cloudfront.net/small_tim_swaan_45717_unsplash_e218e3ac92.jpg
+tags: [""]
 ---
 Public servants who want to conduct interviews with the people that use your service, this post is for you. Recruiting people for service design research can be difficult in any sector, but government has some additional requirements. Though many are warranted due to the government’s position of authority, [others may be due to culture or habit](https://digital.canada.ca/2018/09/07/policy). In this post, we’ll talk about how we recruited Veterans and conducted research.
 

--- a/content/en/blog/posts/the-problem-we-didn’t-expect-while-testing-our-french-newsletter.md
+++ b/content/en/blog/posts/the-problem-we-didn’t-expect-while-testing-our-french-newsletter.md
@@ -11,6 +11,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_newsletter_testing_a152e66ccb.j
 image-alt: 'Doodles in a notebook about planning, iterating, and testing ideas.'
 translationKey: french-newsletter-surveys
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_newsletter_testing_a152e66ccb.jpg
+tags: [""]
 ---
 
 <div class="blog-diary">

--- a/content/en/blog/posts/the-security-in-digital-is-silent.md
+++ b/content/en/blog/posts/the-security-in-digital-is-silent.md
@@ -11,6 +11,7 @@ image: https://de2an9clyit2x.cloudfront.net/the_security_in_digital_is_silent_57
 image-alt: An open lock
 translationKey: the-security-in-digital-is-silent
 thumb: https://de2an9clyit2x.cloudfront.net/small_the_security_in_digital_is_silent_5747f1b463.png
+tags: [""]
 ---
 
 I’ve come to the conclusion that writing about security is harder than actually doing it. This is likely due to having avoided talking or writing about what I’ve done at work for the better part of the last decade. Bear with me, this may be interesting.

--- a/content/en/blog/posts/the-value-of-a-pause:-stories-of-change-in-the-rcmp.md
+++ b/content/en/blog/posts/the-value-of-a-pause:-stories-of-change-in-the-rcmp.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_pause_rcmp_57c7e7d485.jpeg
 image-alt: Four wood blocks displaying a pause symbol.
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_pause_rcmp_57c7e7d485.jpeg
 translationKey: blog-rcmp-most-significant-change
+tags: [""]
 ---
 “Life moves pretty fast. If you don’t stop and look around once in a while, you could miss it.” - Ferris Bueller
 

--- a/content/en/blog/posts/think-big-start-small.md
+++ b/content/en/blog/posts/think-big-start-small.md
@@ -11,6 +11,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_think_big_start_small_2017_2764
 image-alt: Some members of the CDS team celebrating the website launch with a thumbs up
 translationKey: think-big-start-small
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_think_big_start_small_2017_2764703473.jpg
+tags: [""]
 ---
 The UK’s Government Digital Service has a brilliant list of [ten design principles](https://www.gov.uk/design-principles). I still remember the first time I saw it. “Start with user needs”, it read, “not government needs.” Oh my goodness, I thought: this is a real UK government website! That’s …amazing!
 

--- a/content/en/blog/posts/tools-to-do-good-work.md
+++ b/content/en/blog/posts/tools-to-do-good-work.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_tools_for_work_2018_15b0dcce32.
 image-alt: Several MacBook computers covered in stickers laid out on a table.
 translationKey: tools-to-do-good-work
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_tools_for_work_2018_15b0dcce32.jpg
+tags: [""]
 ---
 
 We’ve previously blogged about the importance of [automated testing](https://digital.canada.ca/2018/03/26/automated-testing-blog/), [continuous integration](https://digital.canada.ca/2018/05/16/reducing-risk-through-continuous-deployment/), and some of our early [technology platform choices](https://digital.canada.ca/2017/11/06/technology-choices-at-cds/). In order to adopt modern digital practices, it’s also important to have the tools – both devices and software – that make this possible.

--- a/content/en/blog/posts/toxic-or-positive-masculinity?-how-men-can-shift-workplace-culture.md
+++ b/content/en/blog/posts/toxic-or-positive-masculinity?-how-men-can-shift-workplace-culture.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_positive_masculinity_intro_499c
 image-alt: People helping a garden flourish; some are removing dead plants, some are watering growing plants.
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_positive_masculinity_intro_499c43c730.jpg
 translationKey: blog-positive-masculinity-intro
+tags: [""]
 ---
 When I was visiting my home country, Lebanon, my grandfather used to say, "Son, a good man is someone who finds a respectable wife, has children, and is the main provider for the family." My father would repeat those words to me and my brothers. My close friends have all heard it too. These words set an expectation for men to be powerful and in control. It could (and sometimes does) make men feel superior, giving way to an alpha male who asserts dominance – both at home and at work. 
 

--- a/content/en/blog/posts/understanding-and-designing-for-changing-mindsets-during-a-global-pandemic.md
+++ b/content/en/blog/posts/understanding-and-designing-for-changing-mindsets-during-a-global-pandemic.md
@@ -11,6 +11,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_banner_mindsets_bf393356cd.jpg
 image-alt: 'Four people ranging in emotions from happiness to reluctance.  '
 translationKey: mindsets-covidalert
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_banner_mindsets_bf393356cd.jpg
+tags: [""]
 ---
 It’s December 2020. When thinking about the last nine months of the pandemic, our lives before COVID-19 feel distant. Our concerns at the beginning of the crisis barely resemble how we’re feeling now. Our fears and anxieties about the well-being of our children, the health of our older relatives, the security of our livelihoods, or whether just going outside is worth the risk, change day-to-day depending on the state of the world. 
 

--- a/content/en/blog/posts/unleash-talent-and-four-other-tips-for-changing-government.md
+++ b/content/en/blog/posts/unleash-talent-and-four-other-tips-for-changing-government.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/nordwood_themes_1066398_unsplash_390
 image-alt: '2019 written in fireworks, Photo: NordWood Themes/Unsplash'
 translationKey: unleash-talent
 thumb: https://de2an9clyit2x.cloudfront.net/small_nordwood_themes_1066398_unsplash_390a276ba7.jpg
+tags: [""]
 ---
 After two years building CDS, I wanted to share a few thoughts on what I’ve learned. With our partners, we’re changing how government designs and delivers services, but there’s a long way to go. Here’s how we can get there:
 

--- a/content/en/blog/posts/update-on-our-request-for-proposals.md
+++ b/content/en/blog/posts/update-on-our-request-for-proposals.md
@@ -8,6 +8,7 @@ image: https://de2an9clyit2x.cloudfront.net/rfp_eng_f9ec7032b9.jpg
 image-alt: 'A maple leaf sticker with the words, Strong and Free.'
 translationKey: update-rfp
 thumb: https://de2an9clyit2x.cloudfront.net/small_rfp_eng_f9ec7032b9.jpg
+tags: [""]
 ---
 Thank you to all of the bidders that took the time and effort to respond to our [Request for Proposals](https://buyandsell.gc.ca/procurement-data/tender-notice/PW-18-00841347). Since bidding closed we have been working hard to evaluate the bids, but it’s taking us longer than we would have liked. We know you and your teams need to make plans so here’s an update with our best estimates on timelines and a few reminders.
 

--- a/content/en/blog/posts/using-data-to-meet-people’s-information-needs-during-the-pandemic.md
+++ b/content/en/blog/posts/using-data-to-meet-people’s-information-needs-during-the-pandemic.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/HC_Get_Updates_f9a9c93d65.jpg
 image-alt: An overwhelming amount of data from different sources being funnelled into one clear email. 
 thumb: https://de2an9clyit2x.cloudfront.net/small_HC_Get_Updates_f9a9c93d65.jpg
 translationKey: blog-data-healthcanada-notify
+tags: [""]
 ---
 ## Information overload
 

--- a/content/en/blog/posts/validation-testing-a-way-to-challenge-your-assumptions.md
+++ b/content/en/blog/posts/validation-testing-a-way-to-challenge-your-assumptions.md
@@ -13,6 +13,7 @@ image-alt: >-
   arranged side by side in white pots, in front of a white background.
 translationKey: validation-testing-cra
 thumb: https://de2an9clyit2x.cloudfront.net/small_colourful_cactuses_34eab63a4d.jpg
+tags: [""]
 ---
 Putting people at the centre of our work means trusting that they’re the experts of their own contexts and needs.
 

--- a/content/en/blog/posts/wanted-ceo-cds.md
+++ b/content/en/blog/posts/wanted-ceo-cds.md
@@ -12,6 +12,7 @@ image: https://de2an9clyit2x.cloudfront.net/wanted_ceo_cds_2017_992dcbf98e.jpg
 image-alt: 'Yaprak Baltacıoğlu, Secretary of the Treasury Board'
 translationKey: wanted-ceo-cds
 thumb: https://de2an9clyit2x.cloudfront.net/small_wanted_ceo_cds_2017_992dcbf98e.jpg
+tags: [""]
 ---
 The services our government provides play an important role in the lives of millions of people.
 

--- a/content/en/blog/posts/we-get-by-with-a-little-help-from-our-friends.md
+++ b/content/en/blog/posts/we-get-by-with-a-little-help-from-our-friends.md
@@ -13,6 +13,7 @@ image-alt: >-
   blue sky.
 translationKey: help-from-friends
 thumb: https://de2an9clyit2x.cloudfront.net/small_katka_pavlickova_131100_unsplash_min_3c6c37adef.jpg
+tags: [""]
 ---
 I often get asked by fellow public servants “What authorities did the Canadian Digital Service (CDS) get to operate the way it does?” So I thought I would share the authorities we received from government when CDS was established in 2017:
 

--- a/content/en/blog/posts/we-love-a-good-challenge.md
+++ b/content/en/blog/posts/we-love-a-good-challenge.md
@@ -12,6 +12,7 @@ image-alt: >-
   screen in the background labelled “Challenge accepted.”
 translationKey: we-love-a-good-challenge
 thumb: https://de2an9clyit2x.cloudfront.net/small_aaron_fwd50_challenge_accepted_en_c88e40476f.jpg
+tags: [""]
 ---
 Last summer, the federal government brought together Canadian industry leaders to help guide [economic strategies for Canada](https://www.ic.gc.ca/eic/site/098.nsf/eng/home). One of these, the Digital Industries table – chaired by Shopify CEO [Tobi Lütke](https://twitter.com/tobi) – examined how Canada could become a digital leader. Their report was published in September 2018, and [presents a bold vision](https://www.ic.gc.ca/eic/site/098.nsf/vwapj/ISEDC_Digital_Industries.pdf/$FILE/ISEDC_Digital_Industries.pdf) for Canada as a digital society.
 

--- a/content/en/blog/posts/we-take-security-seriously-why-everyone-at-cds-has-security-keys.md
+++ b/content/en/blog/posts/we-take-security-seriously-why-everyone-at-cds-has-security-keys.md
@@ -11,6 +11,7 @@ image: https://de2an9clyit2x.cloudfront.net/yubikey_3_f8e7460aeb.jpg
 image-alt: A hand pushing their yubikey.
 translationKey: yubikey-post
 thumb: https://de2an9clyit2x.cloudfront.net/small_yubikey_3_f8e7460aeb.jpg
+tags: [""]
 ---
 I have fears; big, big fears. Fears of waking up in the morning and seeing the Canadian Digital Service’s cloud assets vandalized or destroyed because some bad actor got a hold of someone's credentials and decided to muck around. Hey, this fear is real and even the most conscientious of us are vulnerable.
 

--- a/content/en/blog/posts/we’re-launching-an-accelerator-to-test-incremental-investment.md
+++ b/content/en/blog/posts/we’re-launching-an-accelerator-to-test-incremental-investment.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_up_to_speed_030a3f5cc5.jpg
 image-alt: Car speedometer
 translationKey: accelerator-launch
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_up_to_speed_030a3f5cc5.jpg
+tags: [""]
 ---
 In countries making significant progress with digital government, work with the private sector is an important part of the puzzle. Government can’t do it alone. Contracting helps scale modern technology and design methods across the public sector. Businesses bring specialized expertise, flexible surge capacity, scale, and experience with the cutting edge of technology and practice.
 

--- a/content/en/blog/posts/what’s-it-like-to-work-on-a-distributed-team.md
+++ b/content/en/blog/posts/what’s-it-like-to-work-on-a-distributed-team.md
@@ -12,6 +12,7 @@ image-alt: >-
   Hangout
 translationKey: VAC-distributed-interview
 thumb: https://de2an9clyit2x.cloudfront.net/small_google_hangout2_a9a1bb9b37.jpg
+tags: [""]
 ---
 Meet Phil and Emily, distributed team members from Veterans Affairs Canada (VAC) who have been working on the Benefits Finder partnership with us.
 

--- a/content/en/blog/posts/why-canada-needs-a-digital-service.md
+++ b/content/en/blog/posts/why-canada-needs-a-digital-service.md
@@ -13,6 +13,7 @@ image-alt: >-
   Elvas
 translationKey: why-canada-needs-a-digital-service
 thumb: https://de2an9clyit2x.cloudfront.net/small_why_canada_needs_a_digital_service_2017_83f1ff7d59.jpg
+tags: [""]
 ---
 For months, I’ve been working behind the scenes to stand up the Canadian Digital Service. Through this process, I’ve done a lot of thinking about why Canada needs a digital service organization and the potential it has to change how we design government services.
 

--- a/content/en/blog/posts/why-open-source-matters.md
+++ b/content/en/blog/posts/why-open-source-matters.md
@@ -13,6 +13,7 @@ image-alt: >-
   different blocks.
 translationKey: why-open-source-matters
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_open_source_b720f5ece8.jpg
+tags: [""]
 ---
 A few weeks ago, we posted [a Twitter thread](https://twitter.com/CDS_GC/status/1227971000471560197) on what open source is and how it makes online services better. We get a lot of questions about open source software from across the government. Using open source code – and publishing the software code we write – are some of the Canadian Digital Service’s (CDS) most important principles. If you’re curious why, read on!
 

--- a/content/en/blog/posts/yolo-more-like-co-lo-cation-amirite.md
+++ b/content/en/blog/posts/yolo-more-like-co-lo-cation-amirite.md
@@ -11,6 +11,7 @@ image: https://de2an9clyit2x.cloudfront.net/keith_rcmp_blog_66ebe05132.jpg
 image-alt: Photo of Keith smiling while standing outside in downtown Ottawa.
 translationKey: keith-rcmp-blog
 thumb: https://de2an9clyit2x.cloudfront.net/small_keith_rcmp_blog_66ebe05132.jpg
+tags: [""]
 ---
 Yikes.  I’m in a meeting, answering questions from the Chief Information Officer (CIO) of the RCMP. **The C-I-O.** In my nearly 20-year public service career, this was unheard of. But here I am, a developer at the Royal Canadian Mounted Police (RCMP), co-locating at The Canadian Digital Service (CDS) to work on a public reporting tool for victims of cybercrime, advocating for change directly to the CIO. This would have been a foreign concept to me 14 months ago.
 

--- a/content/en/blog/posts/‘security-snack-time’-at-cds.md
+++ b/content/en/blog/posts/‘security-snack-time’-at-cds.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/banner_security_snack_time_a5cd2fbf1
 image-alt: A partially eaten donut, a lock, a cup of coffee, and a computer mouse.
 thumb: https://de2an9clyit2x.cloudfront.net/small_banner_security_snack_time_a5cd2fbf11.jpg
 translationKey: blog-security-snack-time
+tags: [""]
 ---
 What comes to mind when somebody says ‘security training’? 
 

--- a/content/fr/blog/posts/-apprendre-à-rendre-le-contenu-sur-twitter-plus-accessible.md
+++ b/content/fr/blog/posts/-apprendre-à-rendre-le-contenu-sur-twitter-plus-accessible.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/accessibility_tweets_blog_banner_650
 image-alt: Une personne utilisant un lecteur d’écran sur son téléphone.
 thumb: https://de2an9clyit2x.cloudfront.net/small_accessibility_tweets_blog_banner_650f003408.jpg
 translationKey: blog-accessible-tweets 
+tags: [""]
 ---
 Personne n’aime être exclu, et personne n’aime voir ses besoins et ses sentiments ignorés. Du moins, certainement pas moi.
 

--- a/content/fr/blog/posts/5-conseils-pour-faire-de-vos-présentations-de-véritables-bijoux.md
+++ b/content/fr/blog/posts/5-conseils-pour-faire-de-vos-présentations-de-véritables-bijoux.md
@@ -9,7 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/banner_making_presentations_memorabl
 image-alt: Une pierre précieuse verte étincelante entourée de roches. Elle se démarque des autres pierres.
 thumb: https://de2an9clyit2x.cloudfront.net/small_banner_making_presentations_memorable_f9e0ae0042.jpeg
 translationKey: making-presentations-memorable
-tags: ["Conception et communications"]
+tags: [""]
 ---
 Il vous est sans doute déjà arrivé d’assister à une présentation désastreuse… trop longue, verbeuse, visuellement surchargée ou tout simplement difficile à suivre. 
 

--- a/content/fr/blog/posts/7-étapes-vers-des-narrations-visuelles-réussies.md
+++ b/content/fr/blog/posts/7-étapes-vers-des-narrations-visuelles-réussies.md
@@ -13,6 +13,7 @@ image-alt: >-
 translationKey: visual-storyteller-blog
 thumb: https://de2an9clyit2x.cloudfront.net/small_visual_storyteller_533f467c76.jpg
 
+tags: [""]
 ---
 Vous cherchez à rendre vos communications plus efficaces? Laissez les images vous aider à mettre en valeur vos messages.
 

--- a/content/fr/blog/posts/Le-SNC-accueille-son-premier-dirigeant-principal.md
+++ b/content/fr/blog/posts/Le-SNC-accueille-son-premier-dirigeant-principal.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_aaron_snow_eae49285b0.jpg
 image-alt: Aaron Snow
 translationKey: CDS-gets-its-first-CEO
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_aaron_snow_eae49285b0.jpg
+tags: [""]
 ---
 
 En septembre, Yaprak Baltacıoğlu, secrétaire du Conseil du Trésor, [a lancé la recherche du premier dirigeant principal du SNC](https://numerique.canada.ca/2017/09/12/recherche-dirigeant-principal-du-service-numerique-canadien/). Cet exercice a attiré des candidats de partout dans le monde.

--- a/content/fr/blog/posts/a-la-recherche-utilisateur-avec-RNCan.md
+++ b/content/fr/blog/posts/a-la-recherche-utilisateur-avec-RNCan.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_conducting_user_research_with_N
 image-alt: Eman et Jennifer regardent le canevas de proposition de valeur
 translationKey: conducting-user-research-with-NRCan
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_conducting_user_research_with_NRCAN_cb9cb98c0d.jpg
+tags: [""]
 ---
 
 Lorsque Ressources naturelles Canada (RNCan) est venu nous voir avec l’idée d’ouvrir l’accès aux données d’ÉnerGuide, la solution semblait assez évidente: concevoir une interface de programmation d’applications (API) qui permettrait aux utilisateurs d’interroger les données d’ÉnerGuide. Mais d’abord, il fallait valider la solution proposée.

--- a/content/fr/blog/posts/a-la-rescherche-de-la-diversity.md
+++ b/content/fr/blog/posts/a-la-rescherche-de-la-diversity.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_striving_for_diversity_7cb58475
 image-alt: Une bannière de ruban bleu avec les mots « a mari usque ad mare » en jaune.
 translationKey: striving-for-diversity
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_striving_for_diversity_7cb58475fa.jpg
+tags: [""]
 ---
 
 L’un des principaux avantages de travailler pour le Service numérique canadien (SNC) est que nous avons la possibilité de servir les Canadiens tous les jours. Les fonctionnaires s’efforcent d’avoir des répercussions positives sur les gens partout au Canada. En fait, la devise du Canada est *a mari usque ad mare*, qui signifie *d’un océan à l’autre*, et c’est la vérité. Cela dit, l’expression d’un océan à l’autre englobe beaucoup de gens. Les Autochtones, les immigrants, les réfugiés et les familles qui sont ici depuis des générations, des personnes de toutes les cultures, races, religions, identités et origines. Comment pouvons-nous servir tous ces groupes sur des principes d’égalité et d’équité? Pour commencer, nous pouvons bâtir des équipes aussi diversifiées que les gens que nous servons.

--- a/content/fr/blog/posts/aider-les-gens-à-trouver-du-contenu-:-comment-créer-une-barre-de-recherche-sur-un-site-web.md
+++ b/content/fr/blog/posts/aider-les-gens-à-trouver-du-contenu-:-comment-créer-une-barre-de-recherche-sur-un-site-web.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/fr_blog_website_searchbar_c25a896c5b
 image-alt: Icône de la barre de recherche du site Web comportant le texte « Que recherchez-vous »
 thumb: https://de2an9clyit2x.cloudfront.net/small_fr_blog_website_searchbar_c25a896c5b.jpg
 translationKey: blog-website-searchbar
+tags: [""]
 ---
 *Avis à nos lecteurs : ceci n’est PAS un billet de blogue ordinaire. Cet article pose un regard technique sur l’ajout d’une fonctionnalité de recherche à un site Web. Spécialistes du développement Web, ce billet vous est destiné!*
 

--- a/content/fr/blog/posts/aidons-les-canadiens-à-faible-revenu-à-produire-leur-déclaration-de-revenus.md
+++ b/content/fr/blog/posts/aidons-les-canadiens-à-faible-revenu-à-produire-leur-déclaration-de-revenus.md
@@ -16,6 +16,7 @@ image-alt: >-
   main.
 translationKey: Canadians-complete-taxes
 thumb: https://de2an9clyit2x.cloudfront.net/small_img_0880_26a9215f41.jpg
+tags: [""]
 ---
 Tous les jours, les Canadiens utilisent les services gouvernementaux. En tant que fonctionnaires, nous assurons la conception et la prestation de ces services. Bon nombre de ces services sont cruciaux pour les gens qui en ont besoin. Cela veut dire que lorsque les gens ont besoin de services gouvernementaux, ils sont souvent confrontés à de sérieuses difficultés.
 

--- a/content/fr/blog/posts/amélioration-continue-d’alerte-covid.md
+++ b/content/fr/blog/posts/amélioration-continue-d’alerte-covid.md
@@ -18,6 +18,7 @@ image-alt: >-
   COVID.
 translationKey: covid-alert-blog
 thumb: https://de2an9clyit2x.cloudfront.net/small_improving_covid_alert_banner_6e181f5c51.jpg
+tags: [""]
 ---
 <section class="page--outer-container-padding">
    <div class="row">

--- a/content/fr/blog/posts/améliorer-l’intégration-des-nouveaux-employés-en-période-de-télétravail.md
+++ b/content/fr/blog/posts/améliorer-l’intégration-des-nouveaux-employés-en-période-de-télétravail.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/brady_bunch_fef4e4a9a9.jpeg
 image-alt: Un appel vidéo avec x membres de l’équipe à différents endroits. Ils agitent la main et interagissent entre eux, dans un affichage en quadrillage.
 thumb: https://de2an9clyit2x.cloudfront.net/small_brady_bunch_fef4e4a9a9.jpeg
 translationKey: blog-virtual-onboarding
+tags: [""]
 ---
 Lorsque la pandémie s’est déclarée l’an dernier, nos vies personnelles et professionnelles ont été bouleversées du jour au lendemain. De mon côté, le chemin du bureau ne prend maintenant que 8 secondes. La course pour prendre le train le matin, les heures passées dans les embouteillages, s’entasser dans l’ascenseur; tout ça, c’est du passé. Aujourd’hui, je fais un petit arrêt à la machine à café et je rejoins la rencontre quotidienne de mon équipe en un seul clic, la tête reposée. 
 

--- a/content/fr/blog/posts/apprendre-des-gens-qui-veulent-utiliser-notre-service-de-signalement-mais-qui-ne-l’utiliseraient-peut-être-pas-maintenant.md
+++ b/content/fr/blog/posts/apprendre-des-gens-qui-veulent-utiliser-notre-service-de-signalement-mais-qui-ne-l’utiliseraient-peut-être-pas-maintenant.md
@@ -20,6 +20,7 @@ image-alt: >-
 translationKey: reporting-service-checklist
 thumb: https://de2an9clyit2x.cloudfront.net/small_rcmp_prototype_fr_e12e5f1872.jpg
 
+tags: [""]
 ---
 Notre raison d’être au Service numérique canadien (SNC) est d’accorder la priorité aux gens afin de faciliter leur utilisation des services gouvernementaux. Naturellement, pour nous aider à mieux comprendre comment nous pouvons y parvenir, nous parlons beaucoup de recherche avec les gens qui utilisent nos services.
 

--- a/content/fr/blog/posts/attirer-et-recruter-les-meilleurs-talents-avec-un-petit-coup-de-main-de-nos-amis.md
+++ b/content/fr/blog/posts/attirer-et-recruter-les-meilleurs-talents-avec-un-petit-coup-de-main-de-nos-amis.md
@@ -16,6 +16,7 @@ image-alt: >-
   livres.
 translationKey: help-from-friends-HR
 thumb: https://de2an9clyit2x.cloudfront.net/small_beetletoy_a7a60363e2.jpg
+tags: [""]
 ---
 *[On s’en sort avec l’aide de nos amis] (https://numerique.canada.ca/2019/01/31/on-sen-sort-avec-laide-de-nos-amis/) est une série de billets de blogues mettant en vedette les fonctionnaires extraordinaires qui nous permettent, à nous et à nos partenaires, de concevoir et d’offrir de meilleurs services.*
 

--- a/content/fr/blog/posts/b-travailler-dans-les-locaux-de-RNCan.md
+++ b/content/fr/blog/posts/b-travailler-dans-les-locaux-de-RNCan.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_colocating_with_NRCAN_e84609704
 image-alt: Jason et Dave debouts devant l'édifice de Ressources naturelles Canada
 translationKey: colocating-with-NRCan
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_colocating_with_NRCAN_e846097048.jpg
+tags: [""]
 ---
 
 Nous construisons une interface de programmation d’applications (API) publique pour Ressources naturelles Canada (RNCan); cette API vise à ouvrir l’accès aux données ÉnerGuide sur la consommation d’énergie résidentielle. Les détails de ce partenariat font l’objet du billet [La recherche utilisateur avec RNCan&nbsp;: orienter la conception d’une API – Partie 1.](/2018/02/15/a-la-recherche-utilisateur-avec-rncan/)

--- a/content/fr/blog/posts/bonjour-le-monde-canada.md
+++ b/content/fr/blog/posts/bonjour-le-monde-canada.md
@@ -12,6 +12,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_hello_world_canada_548cf9565c.j
 image-alt: Des feuilles d’érable rouge.
 translationKey: hello-world-canada
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_hello_world_canada_548cf9565c.jpg
+tags: [""]
 ---
 
 Bonjour! Le Service numérique canadien a un peu plus d’un an, et comme j’ai eu l’honneur de faire partie de cette équipe depuis maintenant six mois, il est grand temps que j’écrive quelques mots ici.

--- a/content/fr/blog/posts/bâtir-une-communauté-de-pratique-en-offrant-des-évaluations-comme-service.md
+++ b/content/fr/blog/posts/bâtir-une-communauté-de-pratique-en-offrant-des-évaluations-comme-service.md
@@ -16,6 +16,7 @@ image-alt: >-
   cocher dans un calepin.
 translationKey: service-assessments
 thumb: https://de2an9clyit2x.cloudfront.net/small_checklist_bf2f5e5013.jpg
+tags: [""]
 ---
 Il faut une communauté de pratique pour transformer les services gouvernementaux. L’an dernier, le gouvernement du Canada a présenté ses [normes numériques](https://www.canada.ca/fr/gouvernement/systeme/gouvernement-numerique/normes-numeriques-gouvernement-canada.html). Il s’agit d’un ensemble de principes visant à aider les équipes à offrir des services numériques de meilleure qualité aux Canadiens. Depuis leur publication, le Service numérique canadien (SNC) examine comment les ministères peuvent s’évaluer en fonction des normes.
 

--- a/content/fr/blog/posts/ce-que-j’ai-appris-en-travaillant-sur-les-opérations-de-recherche-en-conception.md
+++ b/content/fr/blog/posts/ce-que-j’ai-appris-en-travaillant-sur-les-opérations-de-recherche-en-conception.md
@@ -17,6 +17,7 @@ image-alt: >-
   l’impact qu’ils ont eu sur la personne qu’elle est aujourd’hui.
 translationKey: blog-design-research-ops
 thumb: https://de2an9clyit2x.cloudfront.net/small_anne_marie_blog_banner_b51d016be3.jpg
+tags: [""]
 ---
 Il arrive souvent que les responsabilités d’un poste dépassent la description de poste. Nos valeurs et notre personnalité, les relations que nous construisons et notre approche au travail ont toutes une influence sur l’impact que nous avons et sur la direction qu’un rôle peut prendre.
 

--- a/content/fr/blog/posts/ce-sont-les-gens-qui-comptent.md
+++ b/content/fr/blog/posts/ce-sont-les-gens-qui-comptent.md
@@ -11,6 +11,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_its_about_people_2017_0d56d9b4e
 image-alt: Anatole Papadopoulos parle avec le personnel du SNC.
 translationKey: its-about-people
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_its_about_people_2017_0d56d9b4e9.jpg
+tags: [""]
 ---
 Privilégier les utilisateurs. Voilà la raison d’être du Service numérique canadien. Lorsqu’on parle du «&nbsp;gouvernement numérique&nbsp;», on pense habituellement aux sites Web, aux API et aux applications. Tout cela fait partie du coffre à outils. Pourtant, ce sont les gens – leurs besoins, leurs expériences, leurs frustrations, même leurs espoirs – qui devraient être au cœur des efforts vers un gouvernement numérique.
 

--- a/content/fr/blog/posts/chers-collègues-quelle-est-la-formation-numérique-dont-vous-avez-besoin.md
+++ b/content/fr/blog/posts/chers-collègues-quelle-est-la-formation-numérique-dont-vous-avez-besoin.md
@@ -13,6 +13,7 @@ image: https://de2an9clyit2x.cloudfront.net/screen_shot_2018_11_01_at_3_42_39_pm
 image-alt: Une collection d'outils de travail
 translationKey: digital-training-needs
 thumb: https://de2an9clyit2x.cloudfront.net/small_screen_shot_2018_11_01_at_3_42_39_pm_a3ff96d004.jpg
+tags: [""]
 ---
 **Mise à jour :** *Renforcement de la capacité numérique : le rapport sur l’analyse des besoins en formation est maintenant disponible sur le site Web de l’Université Dalhousie! [Lisez ici ce que nous avons découvert](/2019/08/30/%C3%A9valuer-les-besoins-en-formation-du-gouvernement-pour-lavenir-de-la-prestation-de-services-num%C3%A9riques/). Merci à tous les fonctionnaires qui ont participé au sondage. Vos réponses contribueront à orienter l’apprentissage sur les disciplines numériques émergentes.*
 

--- a/content/fr/blog/posts/choisir-nos-projets.md
+++ b/content/fr/blog/posts/choisir-nos-projets.md
@@ -16,6 +16,7 @@ image: https://de2an9clyit2x.cloudfront.net/picking_our_projects_2017_b3fdfe5d6f
 image-alt: Affiches dans les locaux du SNC.
 translationKey: picking-our-projects
 thumb: https://de2an9clyit2x.cloudfront.net/small_picking_our_projects_2017_b3fdfe5d6f.jpg
+tags: [""]
 ---
 J’ai grandi sur une ferme. Mon enfance a été marquée par la sensation du gravier sous mes pieds, la terre sur mes mains et le bonheur de choisir des fruits et des légumes directement du champ. J’aimerais pouvoir vous dire que choisir des projets est semblable, mais je n’ai toujours pas vu de gravier, de terre, de fruits ou de légumes pendant une discussion portant sur un partenariat (points bonis si vous y arrivez!)
 

--- a/content/fr/blog/posts/circonscrire-un-probleme-de-conception.md
+++ b/content/fr/blog/posts/circonscrire-un-probleme-de-conception.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_framing_a_design_problem_2017_e
 image-alt: Une salle remplie de chaises inoccupées lors d’une cérémonie de citoyenneté.
 translationKey: framing-a-design-problem
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_framing_a_design_problem_2017_ed45b772b5.jpg
+tags: [""]
 ---
 C’est une période emballante au Service numérique canadien (SNC) : nous avons retroussé nos manches et nous nous sommes lancés dans nos premiers projets de prestation de services, tout en travaillant fort pour [choisir nos prochains partenariats](/2017/08/24/choisir-nos-projets/). L’un de nos partenaires pour ces tout premiers projets est Immigration, Réfugiés et Citoyenneté Canada (IRCC).
 

--- a/content/fr/blog/posts/codage-collectif.md
+++ b/content/fr/blog/posts/codage-collectif.md
@@ -14,6 +14,7 @@ image-alt: >-
   web.
 translationKey: community-driven-coding
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_david_https_header_b2045a7bfc.jpg
+tags: [""]
 ---
 
 Si vous cherchez un peu, vous pouvez trouver de la solidarité autour de vous. Le développement de logiciels ouverts n’y fait pas exception. De par sa nature, le développement ouvert trouve sa source dans la collectivité. Grâce au partage, les gens peuvent tirer parti du travail de chacun, ce qui facilite la tâche de tout le monde.

--- a/content/fr/blog/posts/coder-une-activite-dequipe.md
+++ b/content/fr/blog/posts/coder-une-activite-dequipe.md
@@ -11,6 +11,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_team_coding_3f3236a73b.jpg
 image-alt: Un écran d'ordinateur affiche 200 lignes de code JavaScript dans Sublime Text.
 translationKey: coding-is-a-team-activity
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_team_coding_3f3236a73b.jpg
+tags: [""]
 ---
 
 D’après notre expérience, le développement de logiciels doit être un effort d’équipe. Cela ne veut pas dire que plusieurs développeurs contribuent individuellement à une seule base de code; au contraire, toute l’équipe est responsable de chaque ligne de code. Pour tout système de production, on s’attend à ce que tous les codes soient approuvés par au moins un autre développeur, avant qu’il ne soit accepté.

--- a/content/fr/blog/posts/collaboration-productive.md
+++ b/content/fr/blog/posts/collaboration-productive.md
@@ -23,6 +23,7 @@ image-alt: >-
   quotidienne.
 translationKey: productive-collaboration
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_productive_collaboration_b08bf045d4.jpg
+tags: [""]
 ---
 
 Au Service numérique canadien (SNC), nous formons nos équipes de produits pour qu’elles se composent de gestionnaires de produits, de chercheurs, de concepteurs, de développeurs, d’experts en politiques et de spécialistes en communication. Mais le fait de réunir une équipe multidisciplinaire ne signifie pas que la partie la plus difficile est terminée. Toutes les personnes que vous avez rassemblées au sein de votre équipe proviennent de disciplines différentes et chacune a ses propres façons de travailler. Il peut s’agir (sans s’y limiter) du rythme, des outils, des heures, des moments de la journée, des conditions environnementales, des méthodes de communication et des moyens que chaque personne préfère pour donner et recevoir de la rétroaction. Avec tant de variables différentes, il est facile de se sentir rapidement dépassé.

--- a/content/fr/blog/posts/colocalisation-ne-laisser-aucun-membre-de-l’équipe-derrière.md
+++ b/content/fr/blog/posts/colocalisation-ne-laisser-aucun-membre-de-l’équipe-derrière.md
@@ -11,6 +11,7 @@ image-alt: Des parapluies colorés flottant côte à côte dans le ciel.
 translationKey: cra-colocation
 thumb: https://de2an9clyit2x.cloudfront.net/small_colourful_umbrellas_da3560310b.jpg
 
+tags: [""]
 ---
 Je n’arrive pas à croire que j’écris un billet de blogue! En tant que responsable du service pour ce projet à l’Agence du revenu du Canada (ARC), cela fait partie de la longue liste des « premières » que j’ai vécues depuis que j’ai commencé à partager les locaux avec nos partenaires du Service numérique canadien (SNC) il y a un peu plus d’un mois.
 

--- a/content/fr/blog/posts/comment-améliorer-l’utilisabilité-d’un-produit-en-combinant-les-méthodes-qualitative-et-quantitative-de-recherche-en-conception.md
+++ b/content/fr/blog/posts/comment-améliorer-l’utilisabilité-d’un-produit-en-combinant-les-méthodes-qualitative-et-quantitative-de-recherche-en-conception.md
@@ -20,6 +20,7 @@ image-alt: >-
   éclairées.
 translationKey: rcmp-mixed-method
 thumb: https://de2an9clyit2x.cloudfront.net/small_mixed_methods_rcmp_9491d5f5b1.jpg
+tags: [""]
 ---
 Dans toute industrie, la nouveauté vient avec des risques. Nous comprenons donc la prudence, voire l’hésitation, de nos partenaires de la fonction publique face aux nouvelles méthodes que nous proposons afin de fournir des services numériques gouvernementaux.
 

--- a/content/fr/blog/posts/comment-les-chercheurs-du-gouvernement-veillent-à-l’inclusivité-dans-leurs-recherches.md
+++ b/content/fr/blog/posts/comment-les-chercheurs-du-gouvernement-veillent-à-l’inclusivité-dans-leurs-recherches.md
@@ -16,6 +16,7 @@ image-alt: >-
   travail et de nouvelles idées.
 translationKey: inclusive-research-event
 thumb: https://de2an9clyit2x.cloudfront.net/small_inclusive_research_event_4cb5105cda.jpg
+tags: [""]
 ---
 À titre de chercheuses en conception, nous sommes responsables de faire valoir les besoins de chaque personne qui utilise les services du gouvernement. L’une de nos principales préoccupations consiste à mener des recherches qui représentent les besoins de *tous* les utilisateurs — pas seulement les utilisateurs conventionnels. Des facteurs comme la race, les incapacités, l’âge, l’emplacement géographique, le sexe ou l’inhabileté numérique peuvent poser des difficultés pour l’accès aux services gouvernementaux.
 

--- a/content/fr/blog/posts/comment-nommer-avec-soin-les-services-gouvernementaux.md
+++ b/content/fr/blog/posts/comment-nommer-avec-soin-les-services-gouvernementaux.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/banner_blog_naming_gov_services_3e99
 image-alt: Les lettres du mot « service » sous forme de pièces de casse-tête dans le désordre, montrant que tout ne s’emboîte pas toujours!
 thumb: https://de2an9clyit2x.cloudfront.net/small_banner_blog_naming_gov_services_3e9945e4af.jpeg
 translationKey: blog-naming-gov-services
+tags: [""]
 ---
 Les mots que nous utilisons en tant que fonctionnaires pour nommer les services et programmes gouvernementaux sont importants. Ils façonnent les attentes du public. Quand on y pense, ces mots, qui dans un monde idéal ont été soigneusement choisis, montrent aux gens que nous servons que nous pouvons leur offrir des solutions et ressources répondant à leurs besoins. Un nom mal choisi peut prêter à confusion et conduire à des malentendus.   
 

--- a/content/fr/blog/posts/comment-nous-avons-installé-notification-sur-canada-ca.md
+++ b/content/fr/blog/posts/comment-nous-avons-installé-notification-sur-canada-ca.md
@@ -8,6 +8,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_service_canada_notify_227a13a00
 image-alt: ' Montgolfière aux couleurs arc-en-ciel dans le ciel.'
 translationKey: blog-service-canada-notify
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_service_canada_notify_227a13a007.jpg
+tags: [""]
 ---
 [Canada.ca](https://www.canada.ca/fr.html), le site Web centralisé du gouvernement du Canada, utilise maintenant Notification pour envoyer des courriels de réponse automatique aux personnes ayant utilisé son [formulaire de questions et commentaires](https://www.canada.ca/fr/contact/questions.html). Ces notifications leur confirment que leur formulaire a été soumis avec succès à un domaine Canada.ca de confiance.
 

--- a/content/fr/blog/posts/comment-nous-avons-mesuré-notre-prestation-avec-acc-et-pourquoi-c’est-utile.md
+++ b/content/fr/blog/posts/comment-nous-avons-mesuré-notre-prestation-avec-acc-et-pourquoi-c’est-utile.md
@@ -14,6 +14,7 @@ image-alt: >-
   et des services.
 translationKey: by-the-numbers
 thumb: https://de2an9clyit2x.cloudfront.net/small_VAC_Benchmark_Blog_F_Rgood_e716f70b28.jpg
+tags: [""]
 ---
 Si nous mesurons une prestation, nous pouvons savoir si nous l’améliorons. C’est pourquoi au Service numérique canadien, nous aimons savoir où nous en sommes avant de commencer à itérer. De cette façon, nous pouvons constater tout le chemin parcouru après avoir perfectionné un produit ou un service.
 

--- a/content/fr/blog/posts/comment-une-nouvelle-directive-simplifie-l’obtention-de-logiciels-pour-le-gouvernement-du-canada.md
+++ b/content/fr/blog/posts/comment-une-nouvelle-directive-simplifie-l’obtention-de-logiciels-pour-le-gouvernement-du-canada.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/procurement_directive_maze_9e6402d02
 image-alt: Une ligne droite traversant un labyrinthe complexe et menant à un document signé.
 thumb: https://de2an9clyit2x.cloudfront.net/small_procurement_directive_maze_9e6402d02b.jpeg
 translationKey: blog-figma-procurement
+tags: [""]
 ---
 L’annexe B, paragraphe B.1.1.4 de la nouvelle [directive sur la gestion de l’approvisionnement](https://www.tbs-sct.gc.ca/pol/doc-fra.aspx?id=32692) du secrétariat du Conseil du Trésor (SCT) indique que pour les contrats relatifs à des biens et services à faible risque et de faible valeur, Services publics et Approvisionnement Canada (SPAC), Services partagés Canada (SPC) et les équipes d’approvisionnement ministérielles peuvent désormais accepter les modalités commerciales standard. Cela comprend les abonnements, les logiciels, les applications mobiles, les services infonuagiques et les logiciels libres. Cette nouvelle directive entrée en vigueur en mai 2021 s’applique à toutes sortes d’outils que votre équipe et vous pourriez vouloir vous procurer. 
 

--- a/content/fr/blog/posts/communications-et-données-elles-vécurent-heureuses-jusqu’à-la-fin-des-temps.md
+++ b/content/fr/blog/posts/communications-et-données-elles-vécurent-heureuses-jusqu’à-la-fin-des-temps.md
@@ -11,6 +11,7 @@ image: https://de2an9clyit2x.cloudfront.net/dreaming_of_words_7126bfb389.jpg
 image-alt: 'Illustration d''une fille rêvant d''écriture et de livres. '
 translationKey: Data-driven-comms
 thumb: https://de2an9clyit2x.cloudfront.net/small_dreaming_of_words_7126bfb389.jpg
+tags: [""]
 ---
 ## Il était une fois...
 

--- a/content/fr/blog/posts/comprendre-les-mentalités-changeantes-pour-mieux-concevoir-en-temps-de-pandémie.md
+++ b/content/fr/blog/posts/comprendre-les-mentalités-changeantes-pour-mieux-concevoir-en-temps-de-pandémie.md
@@ -15,6 +15,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_banner_mindsets_bf393356cd.jpg
 image-alt: 'Quatre personnes affichant diverses expressions, de la réticence à la joie.'
 translationKey: mindsets-covidalert
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_banner_mindsets_bf393356cd.jpg
+tags: [""]
 ---
 Nous sommes en décembre 2020. Quand nous réfléchissons aux neuf derniers mois de pandémie, nos vies d’avant la COVID-19 semblent bien loin. Les préoccupations que nous avions au début de la crise ressemblent à peine à celles d’aujourd’hui. Que nos peurs et nos craintes concernent le bien-être de nos enfants, la santé de nos aînés, notre stabilité d’emploi, ou le risque de sortir dehors, elles changent chaque jour selon l’état de notre monde.
 

--- a/content/fr/blog/posts/conception-de-services-a-nos-idees.md
+++ b/content/fr/blog/posts/conception-de-services-a-nos-idees.md
@@ -14,6 +14,7 @@ image-alt: >-
   tourbillonnent au-dessus de leurs têtes.
 translationKey: service-design-thats-our-jam
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_jam_header_123dc590b3.jpg
+tags: [""]
 ---
 
 Le 21 juin, le Service numérique canadien (SNC) a organisé son tout premier [atelier de conception](https://www.youtube.com/watch?v=S_XeFWoR9uU), qui a réuni 30 participants de l’Agence du revenu du Canada (ARC) et d’Emploi et Développement social Canada (EDSC). Avec l’aide de mentors en conception, les participants ont échangé des idées sur des enjeux actuels quant aux services du gouvernement du Canada.

--- a/content/fr/blog/posts/concevoir-pour-le-canada.md
+++ b/content/fr/blog/posts/concevoir-pour-le-canada.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_designing_for_canada_2017_a6cf2
 image-alt: 'Chris Govias, Design'
 translationKey: designing-for-canada
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_designing_for_canada_2017_a6cf251b7c.jpg
+tags: [""]
 ---
 Après un bref congé sabbatique et une décennie passée au Royaume-Uni, je suis fier d’annoncer que je serai le premier chef de la conception au Service numérique canadien (SNC), une nouvelle initiative du gouvernement du Canada.
 

--- a/content/fr/blog/posts/congé-civique-intégrer-les-talents-du-privé-dans-le-secteur-technologique-public.md
+++ b/content/fr/blog/posts/congé-civique-intégrer-les-talents-du-privé-dans-le-secteur-technologique-public.md
@@ -15,6 +15,7 @@ image-alt: >-
   main.
 translationKey: civic-leave
 thumb: https://de2an9clyit2x.cloudfront.net/small_small_maple_leafs_652f66ae34.jpg
+tags: [""]
 ---
 Il faut une variété de personnes qualifiées pour créer et offrir des services numériques gouvernementaux de qualité. Ici, au Service numérique canadien (SNC), nous avons recours à des équipes multidisciplinaires pour concevoir des services simples et efficaces pour les Canadiens. Ces équipes possèdent des compétences et des expériences variées, ainsi qu’une expertise provenant de divers secteurs et même de différents pays.
 

--- a/content/fr/blog/posts/conjuguer-vitesse-et-prudence-:-le-développement-«-agile-»-au-gouvernement.md
+++ b/content/fr/blog/posts/conjuguer-vitesse-et-prudence-:-le-développement-«-agile-»-au-gouvernement.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/banner_blog_fast_safe_agile_b003ff8c
 image-alt: Deux casques protecteurs. L’un pour la motocyclette représentant la vitesse, et l’autre à coque dure signifiant la prudence.
 thumb: https://de2an9clyit2x.cloudfront.net/small_banner_blog_fast_safe_agile_b003ff8c43.jpg
 translationKey: blog-fast-safe-agile
+tags: [""]
 ---
 C’est le moment idéal de travailler dans le domaine de la prestation de services numériques. Les gens sont plus connectés que jamais et s’attendent à avoir accès à des services numériques modernes. Parallèlement, le développement agile — qui prévoit le développement et l’essai de prototypes en quelques semaines plutôt que de consacrer des années à la planification — s’est imposé. 
 

--- a/content/fr/blog/posts/cote-humain-de-la-citoyennete.md
+++ b/content/fr/blog/posts/cote-humain-de-la-citoyennete.md
@@ -14,6 +14,7 @@ image-alt: >-
   à une cérémonie à Vancouver
 translationKey: human-story-behind-citizenship
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_human_story_citizenship1_76d5a3f84e.jpg
+tags: [""]
 ---
 
 Au gouvernement, nous offrons des services qui répondent aux besoins humains fondamentaux, c’est-à-dire l’appartenance, la sécurité et les relations humaines. Devenir citoyen d’un nouveau pays est l’une des expériences de vie les plus émouvantes qu’une personne vivra et marque la fin d’un long cheminement.

--- a/content/fr/blog/posts/courtes-et-fréquentes-:-faire-de-la-critique-une-pratique-quotidienne.md
+++ b/content/fr/blog/posts/courtes-et-fréquentes-:-faire-de-la-critique-une-pratique-quotidienne.md
@@ -10,6 +10,7 @@ image-alt: Un groupe de 7 personnes se réunit virtuellement pendant 15 minutes.
 
 thumb: https://de2an9clyit2x.cloudfront.net/small_15_minutes_meetings_91e0181bab.jpg
 translationKey: blog-content-critiques
+tags: [""]
 ---
 Les critiques d’équipe sont une pratique exemplaire bien connue des concepteurs de contenu. Mais nous avons eu du mal à savoir comment les mettre en oeuvre au Service numérique canadien (SNC). Pendant longtemps, nous avions à notre horaire quotidien une période de critique facultative que n’importe qui pouvait utiliser à tout moment. Mais puisque ce n’était pas obligatoire, presque personne ne s’y présentait. Ainsi, après des réflexions à la fin de l’automne, nous avons commencé la nouvelle année avec une nouvelle stratégie.   
 

--- a/content/fr/blog/posts/créer-avec-l’intention-d’apprendre-et-de-s’améliorer-:-le-cas-de-notre-barre-de-recherche.md
+++ b/content/fr/blog/posts/créer-avec-l’intention-d’apprendre-et-de-s’améliorer-:-le-cas-de-notre-barre-de-recherche.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/FR_Search_bar_iteration_e2f89d87f4.j
 image-alt: Illustration graphique d’une équipe modifiant et améliorant conjointement la barre de recherche d’un site Web. 
 thumb: https://de2an9clyit2x.cloudfront.net/small_FR_Search_bar_iteration_e2f89d87f4.jpg
 translationKey: blog-website-searchbar-feedback
+tags: [""]
 ---
 À quoi bon fournir des renseignements utiles sur un site Web, s’ils sont introuvables? 
 

--- a/content/fr/blog/posts/créer-des-services-inclusifs-n’est-pas-une-question-de-perfection.md
+++ b/content/fr/blog/posts/créer-des-services-inclusifs-n’est-pas-une-question-de-perfection.md
@@ -12,6 +12,7 @@ image-alt: >-
   utiliser son ordinateur.
 translationKey: not-perfect
 thumb: https://de2an9clyit2x.cloudfront.net/small_mg_9837_2_7bc5f33d0f.jpg
+tags: [""]
 ---
 L'accessibilité a la réputation d'être difficile, et même parfois impossible à réaliser. Pourtant, l’élaboration de services inclusifs qui conviennent à tous n’est pas une question de perfection. C’est une question d’efforts et de progrès. Et lorsqu’on déploie ce genre d’efforts chaque jour, la transformation s’opère. À l’opposé, si l’on ne fait rien, les gens qui ont le plus besoin de nos services ne pourront pas y accéder.
 

--- a/content/fr/blog/posts/c’est-comment-travailler-dans-une-équipe-géographiquement-dispersée.md
+++ b/content/fr/blog/posts/c’est-comment-travailler-dans-une-équipe-géographiquement-dispersée.md
@@ -12,6 +12,7 @@ image: https://de2an9clyit2x.cloudfront.net/google_hangout2_a9a1bb9b37.jpg
 image-alt: 'Phil et Emily partagent un café avec un collègue utilisant Google Hangout. '
 translationKey: VAC-distributed-interview
 thumb: https://de2an9clyit2x.cloudfront.net/small_google_hangout2_a9a1bb9b37.jpg
+tags: [""]
 ---
 Rencontrez Phil et Emily, des membres d’équipe géographiquement dispersés d’Anciens Combattants Canada (ACC) qui ont travaillé avec nous au sein du partenariat de recherche d’avantages et de services.
 

--- a/content/fr/blog/posts/c’est-quoi-au-juste-un-gestionnaire-de-produits.md
+++ b/content/fr/blog/posts/c’est-quoi-au-juste-un-gestionnaire-de-produits.md
@@ -17,6 +17,7 @@ image-alt: >-
   Waterloo, Toronto et Ottawa.
 translationKey: product-manager-QA
 thumb: https://de2an9clyit2x.cloudfront.net/small_pm_banner_fix_646dadacee.jpg
+tags: [""]
 ---
 
 Si vous tombez sur quelqu’un de très organisé, curieux, adaptatif, communicatif, empathique et passionné par l’élimination d’obstacles pour faire avancer les choses, vous venez de rencontrer soit un surhumain, soit un gestionnaire de produits.

--- a/content/fr/blog/posts/dans-le-monde-numerique-la-securite-se-cache.md
+++ b/content/fr/blog/posts/dans-le-monde-numerique-la-securite-se-cache.md
@@ -12,6 +12,7 @@ image: https://de2an9clyit2x.cloudfront.net/the_security_in_digital_is_silent_57
 image-alt: Un cadenas ouvert
 translationKey: the-security-in-digital-is-silent
 thumb: https://de2an9clyit2x.cloudfront.net/small_the_security_in_digital_is_silent_5747f1b463.png
+tags: [""]
 ---
 
 J’en arrive à la conclusion qu’écrire sur la sécurité est en fait plus difficile que de la faire appliquer. Cela est probablement attribuable au fait que j’ai évité de parler de mes activités au travail ou d’écrire à ce sujet pendant la majeure partie des dix dernières années. Permettez-moi de vous en dire plus, ça pourrait devenir intéressant.

--- a/content/fr/blog/posts/ddp.md
+++ b/content/fr/blog/posts/ddp.md
@@ -12,6 +12,7 @@ image: https://de2an9clyit2x.cloudfront.net/rfp_fr_3ac06f0e03.jpg
 image-alt: 'Des autocollants en forme de feuilles d''érables avec les mots, fort et libre.'
 translationKey: rfp
 thumb: https://de2an9clyit2x.cloudfront.net/small_rfp_fr_3ac06f0e03.jpg
+tags: [""]
 ---
 Aujourd'hui, nous (le Service numérique canadien) avons lancé une [demande de propositions](https://achatsetventes.gc.ca/donnees-sur-l-approvisionnement/appels-d-offres/PW-18-00841347).
 

--- a/content/fr/blog/posts/de-la-conception-au-développement-la-pluridisciplinarité-au-snc.md
+++ b/content/fr/blog/posts/de-la-conception-au-développement-la-pluridisciplinarité-au-snc.md
@@ -12,6 +12,7 @@ image-alt: >-
   personnes attendent pour traverser la rue.
 translationKey: working-across-disciplines
 thumb: https://de2an9clyit2x.cloudfront.net/small_yoel_j_gonzalez_304137_unsplash_64d7101ca1.jpeg
+tags: [""]
 ---
 J’ai suivi le programme Interactive Multimedia and Design (Conception et multimédias interactifs) à l’université, et j’y ai acquis une solide base à la fois en conception et en développement. Les professeurs nous disaient qu’on travaillerait probablement à la croisée de ces deux disciplines, assurant le lien entre elles. Vers la fin de mon programme, j’ai décidé de me concentrer sur la conception. J’étais loin de savoir que, quelques années plus tard, j’apprendrais à nouveau à coder.
 

--- a/content/fr/blog/posts/de-la-conception-d’abord-aux-utilisateurs-d’abord.md
+++ b/content/fr/blog/posts/de-la-conception-d’abord-aux-utilisateurs-d’abord.md
@@ -17,6 +17,7 @@ image-alt: >-
   groupe de personnes en-haut.
 translationKey: from-build-first-to-users-first
 thumb: https://de2an9clyit2x.cloudfront.net/small_fullsizeoutput_55_43eb2f1cba.jpg
+tags: [""]
 ---
 Au Service numérique canadien (SNC), nous sommes heureux de collaborer avec les ministères afin de concevoir de meilleurs [services](https://numerique.canada.ca/produits/). Nous sommes également impatients de partager les leçons apprises de ces expériences pour tenter d’aider les autres dans leur propre travail.
 

--- a/content/fr/blog/posts/de-petits-gestes-ayant-des-retombées-significatives.md
+++ b/content/fr/blog/posts/de-petits-gestes-ayant-des-retombées-significatives.md
@@ -12,6 +12,7 @@ image-alt: >-
   que des interprètes gestuels se trouvent derrière eux.
 translationKey: small-acts-big-impact
 thumb: https://de2an9clyit2x.cloudfront.net/small_diversity_day_banner_image_74eb3779fb.jpg
+tags: [""]
 ---
 Des équipes diversifiées et inclusives offrent des services qui le sont tout autant. C’est pourquoi le vendredi 8 février, le Service numérique canadien a tenu l’événement [Diversité au sein des services numériques](https://www.eventbrite.ca/e/diversity-in-digital-services-diversite-au-sein-des-services-numeriques-registration-51465629082), une journée destinée à échanger des idées à propos de la diversité et de l’inclusion des équipes, ainsi que de leur incidence sur la prestation de meilleurs services.
 

--- a/content/fr/blog/posts/des-avis-de-confidentialité-et-de-consentement-en-un-clin-d’œil.md
+++ b/content/fr/blog/posts/des-avis-de-confidentialité-et-de-consentement-en-un-clin-d’œil.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/fr_banner_consent_generator_94dddc2f
 image-alt: Un site Web du gouvernement du Canada intitulé « Créer un formulaire pour le recrutement et les tests par interception », affiché sur un écran d’ordinateur portable et un téléphone mobile.
 thumb: https://de2an9clyit2x.cloudfront.net/small_fr_banner_consent_generator_94dddc2fa6.jpeg
 translationKey: blog-consent-generator
+tags: [""]
 ---
 Fournir de bons services n’est pas seulement une question de technologie. Il faut savoir répondre aux attentes élevées d’un public qui peut suivre à la seconde près la livraison d’une pizza ou payer un café en appuyant sur un bouton dans une appli. Il s’agit de comprendre comment les gens naviguent dans le monde. Pour ce faire, il faut mener de courtes recherches fréquentes auprès des utilisateurs visés. 
 

--- a/content/fr/blog/posts/des-formulaires-gouvernementaux-de-toute-espèce.md
+++ b/content/fr/blog/posts/des-formulaires-gouvernementaux-de-toute-espèce.md
@@ -18,6 +18,7 @@ image-alt: >-
   des ailes de papillon.
 translationKey: form-use-cases
 thumb: https://de2an9clyit2x.cloudfront.net/small_menagerie_banner_3376fc1155.jpg
+tags: [""]
 ---
 > Imaginez ce qui suit : vous cherchez sur Internet la marche à suivre pour demander un permis dont vous avez besoin. Vous tombez sur une page Web gouvernementale comprenant sept paragraphes sur les critères d’admissibilité. Après les avoir lus, vous ne savez toujours pas avec certitude si vous répondez aux critères, mais vous décidez quand même de faire votre demande. Le bouton « Faire une demande » vous entraîne alors vers un message vous invitant à télécharger un fichier PDF. Au moment où vous essayez de l’ouvrir, vous apprenez qu’il vous faudrait aussi un éditeur de fichiers PDF, que vous n’avez pas et n’êtes pas prêt à acheter. Vous décidez donc d’imprimer le document pour le remplir à la main. Le formulaire fait 4 pages et contient 37 questions. Ouf, ce sera long à remplir. Vous le mettez donc de côté, préférant y revenir lorsque vous aurez une bonne heure devant vous pour vous y atteler. Lorsque ce moment vient enfin, une semaine plus tard, vous vous rendez compte que seule la moitié des champs à remplir s’appliquent à votre situation. De plus, vous êtes loin de bien saisir l’information demandée dans les questions. Une fois votre formulaire rempli, vous le numérisez et l’envoyez par courriel, puis vous vous croisez les doigts et attendez.
 

--- a/content/fr/blog/posts/dircc-au-snc.md
+++ b/content/fr/blog/posts/dircc-au-snc.md
@@ -14,6 +14,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_amir_7d10074bf1.jpg
 image-alt: Amir dans l'espace de travail du SNC.
 translationKey: ircc-to-cds
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_amir_7d10074bf1.jpg
+tags: [""]
 ---
 
 À l'origine, j'avais entendu parler du Service numérique canadien (SNC) par mon gestionnaire à IRCC et, en un rien de temps, je commençais à traquer leurs [répertoires GitHub](https://github.com/cds-snc) et à en apprendre davantage sur une bibliothèque frontale appelée [React](https://reactjs.org/). J'étais enthousiaste de sortir de mon silo et de collaborer dans ce qui semblait être un environnement où l'on travaillait avec de nouvelles technologies.

--- a/content/fr/blog/posts/donner-aux-utilisateurs-les-moyens-de-réussir.md
+++ b/content/fr/blog/posts/donner-aux-utilisateurs-les-moyens-de-réussir.md
@@ -16,6 +16,7 @@ description: >-
 image-translation: null
 translationKey: setting-users-up-for-success-with-content-design
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_setting_up_users_for_success_0ab67b7ff1.jpg
+tags: [""]
 ---
 
 Vous avez peut-être déjà lu que le SNC travaille avec [Immigration, Réfugiés et Citoyenneté Canada (IRCC)](https://numerique.canada.ca/2017/10/24/circonscrire-un-probleme-de-conception/) pour rendre le processus de [report d’un rendez-vous d’examen de citoyenneté](https://numerique.canada.ca/2018/04/13/reporter-un-rendez-vous-dexamen/) aussi pratique et facile que possible pour les demandeurs, tout en facilitant la vie du personnel administratif.

--- a/content/fr/blog/posts/données-qualitatives-inconfortables-oui-mais-elles-valent-le-coup.md
+++ b/content/fr/blog/posts/données-qualitatives-inconfortables-oui-mais-elles-valent-le-coup.md
@@ -14,6 +14,7 @@ image-alt: >-
   papillons adhésifs de différentes couleurs.
 translationKey: data-driven-service
 thumb: https://de2an9clyit2x.cloudfront.net/small_rcmp_data_blog_97a57c658d.jpg
+tags: [""]
 ---
 Je suis un grand lecteur. J’adore les livres. Mais j’ai parfois du mal à en choisir un.
 

--- a/content/fr/blog/posts/découvrez-comment-votre-ministère-peut-offrir-de-meilleurs-services.md
+++ b/content/fr/blog/posts/découvrez-comment-votre-ministère-peut-offrir-de-meilleurs-services.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/exporation_map_b1482d69bd.jpeg
 image-alt: Une carte pleine de symboles numériques. Au centre, il y a un ordinateur portatif avec une paire de jumelles regardant de l’écran.
 thumb: https://de2an9clyit2x.cloudfront.net/small_exporation_map_b1482d69bd.jpeg
 translationKey: blog-questions-we-explore
+tags: [""]
 ---
 Comme nous l’avons vu dans [Explorer les conditions de la prestation de services numériques](https://numerique.canada.ca/2021/04/07/explorer-les-conditions-de-la-prestation-de-services-num%C3%A9riques/), la prestation de meilleurs services numériques, c’est un peu comme le jardinage. « Plantez toutes les fleurs que vous voudrez; si les conditions ne sont pas propices à la croissance, les graines ne germeront pas et le jardin ne fleurira pas. » 
 

--- a/content/fr/blog/posts/démystifier-les-mythes-des-équipes-de-talents-pour-embaucher-des-équipes-multidisciplinaires.md
+++ b/content/fr/blog/posts/démystifier-les-mythes-des-équipes-de-talents-pour-embaucher-des-équipes-multidisciplinaires.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/banner_ochro_blog_8f66eccf8f.jpeg
 image-alt: Une courtepointe tissée avec différents patchs, dessins et membres de l'équipe.
 thumb: https://de2an9clyit2x.cloudfront.net/small_banner_ochro_blog_8f66eccf8f.jpeg
 translationKey: blog-busting-talent-myths
+tags: [""]
 ---
 Nous avons récemment parlé de la façon dont [on s’en sort avec l’aide de nos amis](https://numerique.canada.ca/2019/03/18/attirer-et-recruter-les-meilleurs-talents-avec-un-petit-coup-de-main-de-nos-amis/).  L'une des questions les plus fréquentes que nous recevons est de savoir comment embaucher des équipes multidisciplinaires. Nous avons donc communiqué avec le Bureau de la dirigeante principale des ressources humaines (BDPRH) pour obtenir des réponses à nos questions et permettre ainsi de démystifier certains mythes.
 

--- a/content/fr/blog/posts/déplacer-le-contenu-du-code-vers-le-nuage.md
+++ b/content/fr/blog/posts/déplacer-le-contenu-du-code-vers-le-nuage.md
@@ -11,6 +11,7 @@ image: https://de2an9clyit2x.cloudfront.net/magnificent_cloud_ac2e627c55.jpg
 image-alt: Un nuage magnifique s’élève au-dessus des arbres.
 translationKey: from-code-to-cloud
 thumb: https://de2an9clyit2x.cloudfront.net/small_magnificent_cloud_ac2e627c55.jpg
+tags: [""]
 ---
 Au Service numérique canadien (SNC), nous travaillons actuellement sur une [application Web] (https://github.com/cds-snc/vac-benefits-directory) avec Anciens Combattants Canada (ACC). L’application aidera les vétérans et leurs familles à trouver des avantages et des programmes qui leur conviennent. Cela signifie que cette application doit surveiller beaucoup de contenu, soit le texte d’interface, les titres et les descriptions en une ligne des avantages, les questions à choix multiples, les étiquettes associées aux prestations, l’adresse des bureaux d’ACC et d’autres informations, dont aucune ne contenait des données ou des renseignements personnels. Bien sûr, tout ce texte est en anglais et en français.
 

--- a/content/fr/blog/posts/développer-la-recherche-en-conception-au-gouvernement-du-canada.md
+++ b/content/fr/blog/posts/développer-la-recherche-en-conception-au-gouvernement-du-canada.md
@@ -20,6 +20,7 @@ image-alt: >-
   rouge.
 translationKey: design-research
 thumb: https://de2an9clyit2x.cloudfront.net/small_puzzle_f193470c2c.jpg
+tags: [""]
 ---
 La recherche en conception (ou la recherche sur les utilisateurs) nous aide à comprendre les gens qui utilisent nos services. Si nous les comprenons, nous pouvons mieux répondre à leurs besoins. Nous avons vu à quel point la recherche en conception est importante pour assurer la prestation de services numériques axés sur les personnes dans le cadre de notre travail avec nos partenaires. Nous avons également vu à quel point elle peut facilement être confondue avec la recherche sur l’opinion publique (ROP).
 

--- a/content/fr/blog/posts/développer-un-service-efficace-de-notification-d’exposition-comme-alerte-covid.md
+++ b/content/fr/blog/posts/développer-un-service-efficace-de-notification-d’exposition-comme-alerte-covid.md
@@ -19,6 +19,7 @@ image-alt: >-
   équilibre.
 translationKey: covid-alert-utility-scale
 thumb: https://de2an9clyit2x.cloudfront.net/small_covid_alert_vision_banner_5a8a8a87f1.jpg
+tags: [""]
 ---
 *Le 31 juillet 2020, nous avons lancé Alerte COVID, le service canadien de notification d’exposition à la COVID-19. L’application mobile a été développée ouvertement. Pour poursuivre dans la même veine, nous publierons une série de billets de blogue qui expliquent les choix que nous faisons à mesure que nous continuons de mettre à jour, de tester et d’itérer ce service.*
 

--- a/content/fr/blog/posts/elaborer-un-plan-de-researche.md
+++ b/content/fr/blog/posts/elaborer-un-plan-de-researche.md
@@ -12,6 +12,7 @@ image-alt: >-
   des fleurs violettes à la droite.
 translationKey: building-a-research-plan
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_building_a_research_plan_54517b04ce.jpg
+tags: [""]
 ---
 
 Une bonne phase de découverte vous fournit toute l’information dont vous avez besoin pour définir le ou les problèmes que vous voulez résoudre. Notre phase de découverte nous a permis de réunir des preuves qui indiquent qu’il était nécessaire de sensibiliser davantage les vétérans à la façon d’accéder les programmes, les services et les prestations qui leur sont offertes par Anciens Combattants Canada (ACC).

--- a/content/fr/blog/posts/embauche-au-snc.md
+++ b/content/fr/blog/posts/embauche-au-snc.md
@@ -12,6 +12,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_hiring_2018_0d71687f48.jpg
 image-alt: Membres de l’équipe du SNC
 translationKey: hiring-at-cds
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_hiring_2018_0d71687f48.jpg
+tags: [""]
 ---
 Notre manière de faire du recrutement et de renforcer l’effectif d’une équipe de services numériques qui se met immédiatement au travail et qui aide à relever les défis liés aux services dans l’ensemble du gouvernement suscite beaucoup d’intérêt. Voilà pourquoi je suis ravie de bloguer sur les pratiques d’embauche au SNC.
 

--- a/content/fr/blog/posts/en-pleine-croissance-à-spac-conception-de-services-et-recherche-en-conception.md
+++ b/content/fr/blog/posts/en-pleine-croissance-à-spac-conception-de-services-et-recherche-en-conception.md
@@ -14,6 +14,7 @@ image: https://de2an9clyit2x.cloudfront.net/pspc_team_1_d45ef92076.jpg
 image-alt: Photo de l’équipe de recherche en conception à SPAC.
 translationKey: emilio-pspc
 thumb: https://de2an9clyit2x.cloudfront.net/small_pspc_team_1_d45ef92076.jpg
+tags: [""]
 ---
 Lorsqu’on parle de la conception de services au gouvernement, il est surtout question de la création de services hors pair offerts aux citoyens. Cela est conforme à notre but principal : nous travaillons pour servir les citoyens. Nous devons par conséquent faire en sorte que les citoyens soient placés au cœur des services.
 

--- a/content/fr/blog/posts/entrevue-de-départ-d’eva-une-petite-promenade-du-côté-privé.md
+++ b/content/fr/blog/posts/entrevue-de-départ-d’eva-une-petite-promenade-du-côté-privé.md
@@ -14,6 +14,7 @@ image-alt: >-
   peluche orange portant un chapeau de requin.
 translationKey: take-a-walk-on-the-private-side
 thumb: https://de2an9clyit2x.cloudfront.net/small_eva_blog_6027e5f0f8.jpg
+tags: [""]
 ---
 L’une de nos développeuses bien-aimées, Eva Demers-Brett, membre de l’équipe du gouvernement ouvert (GO), nous quitte ce mois-ci pour entreprendre une aventure passionnante dans le secteur privé 😢. Ce sera la première fois de sa carrière de développeuse qu’elle travaillera à l’extérieur de la fonction publique; c’est pourquoi nous voulions connaître ses réflexions et les leçons qu’elle gardera en tête tandis qu’elle découvre le secteur privé.
 

--- a/content/fr/blog/posts/explorer-les-conditions-de-la-prestation-de-services-numériques.md
+++ b/content/fr/blog/posts/explorer-les-conditions-de-la-prestation-de-services-numériques.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/digital_gardeners_65c51a0b12.jpeg
 image-alt: Une collection de fleurs, de feuilles et d'insectes.
 thumb: https://de2an9clyit2x.cloudfront.net/small_digital_gardeners_65c51a0b12.jpeg
 translationKey: blog-digital-gardeners
+tags: [""]
 ---
 Lors de mon arrivée au Service numérique canadien (SNC), j'étais ravi de travailler avec une équipe qui cherchait à changer la façon dont le gouvernement offre ses services. Dans mes rôles précédents, j’ai travaillé avec plusieurs équipes et projets visant à faire de nouvelles choses pour mieux servir les gens, avec divers degrés de succès. J'avais hâte d'apporter mon expérience gouvernementale au SNC et de contribuer à sa mission.   
 

--- a/content/fr/blog/posts/faire-confiance-aux-humains-et-aux-robots.md
+++ b/content/fr/blog/posts/faire-confiance-aux-humains-et-aux-robots.md
@@ -11,6 +11,7 @@ image: https://de2an9clyit2x.cloudfront.net/grass_lawn_robot_ee4fa0e7f5.jpg
 image-alt: 'Un petit robot en bois se tient debout dans une pelouse verdoyante. '
 translationKey: trust-humans-and-robots
 thumb: https://de2an9clyit2x.cloudfront.net/small_grass_lawn_robot_ee4fa0e7f5.jpg
+tags: [""]
 ---
 Le développement de produits et la prestation de services efficaces ne sont rien sans la confiance. En tant qu’équipe de prestation au SNC, nous parlons souvent à nos partenaires de nous accorder la confiance pour les aider à quitter leurs zones de confort et à essayer de nouvelles approches.
 

--- a/content/fr/blog/posts/faire-equipe-pour-mieux-servir-les-anciens-combattants.md
+++ b/content/fr/blog/posts/faire-equipe-pour-mieux-servir-les-anciens-combattants.md
@@ -12,6 +12,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_pei_banner_b2696e820b.jpg
 image-alt: Falaise rouge bordée d’herbe surplombant la mer.
 translationKey: teaming-up-to-deliver-better-outcomes-for-veterans
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_pei_banner_b2696e820b.jpg
+tags: [""]
 ---
 
 Une petite équipe du Service numérique canadien (SNC) a récemment eu la chance de visiter l’Île-du-Prince-Édouard, située au large des côtes maritimes du Canada. Nous y étions invités par [Anciens Combattants Canada](http://www.veterans.gc.ca/fra) (ACC) avec qui nous collaborons pour améliorer la recherche en ligne de prestations pour les anciens combattants.

--- a/content/fr/blog/posts/faire-une-bonne-première-impression-l’intégration-c’est-important.md
+++ b/content/fr/blog/posts/faire-une-bonne-première-impression-l’intégration-c’est-important.md
@@ -16,6 +16,7 @@ image-alt: >-
   bureau étant recouvert d'autocollants, de chocolats et de confettis.
 translationKey: onboarding-matters
 thumb: https://de2an9clyit2x.cloudfront.net/small_onboarding_banner_fitted_12c3d9a91b.jpg
+tags: [""]
 ---
 En tant qu’organisme en pleine expansion, nous accueillons de nouveaux employés quasiment toutes les semaines. S’il s’agit de routine pour nous, c’est un événement unique pour les employés qui commencent. Un nouvel emploi peut être stressant, et la décision de garder son poste ou de passer à autre chose se prend souvent lors des premiers jours. Il est donc essentiel que nous créions une excellente expérience d’intégration. Après tout, les personnes sont au cœur de notre travail — il ne faut pas l’oublier.
 

--- a/content/fr/blog/posts/former-une-équipe-multidisciplinaire-à-edsc-pour-mieux-servir-les-gens.md
+++ b/content/fr/blog/posts/former-une-équipe-multidisciplinaire-à-edsc-pour-mieux-servir-les-gens.md
@@ -16,6 +16,7 @@ image: https://de2an9clyit2x.cloudfront.net/mic_6347afc292.jpg
 image-alt: microphone à condensateur sur fond noir
 translationKey: building-a-multidisciplinary-team-at-ESDC-to-serve-people-better
 thumb: https://de2an9clyit2x.cloudfront.net/small_mic_6347afc292.jpg
+tags: [""]
 ---
 À titre de gestionnaire de la Stratégie d’amélioration des services du Régime de pensions du Canada à Emploi et Développement social Canada (EDSC), j’ai contribué à la constitution de l’équipe multidisciplinaire au Service numérique canadien (SNC) qui travaille à l’amélioration du Régime de pensions du Canada (RPC) pour les personnes qui demandent des prestations d’invalidité.
 

--- a/content/fr/blog/posts/gc-notification-maintenant-en-version-bêta.md
+++ b/content/fr/blog/posts/gc-notification-maintenant-en-version-bêta.md
@@ -14,6 +14,7 @@ image-alt: >-
   d’accueil de Notification GC en version bêta
 translationKey: blog-notify-beta
 thumb: https://de2an9clyit2x.cloudfront.net/small_notify_blog_beta_banner_fr_56dffd2eb1.jpg
+tags: [""]
 ---
 Depuis le lancement de l’outil Notification GC en 2019, nous avons aidé des équipes gouvernementales à envoyer [plus de 8,8 millions de notifications](https://notification.canada.ca/activity). Suite au développement de la première version du service et de son amélioration en fonction des besoins des utilisateurs, nous nous faisons un grand plaisir d’annoncer que Notification GC passe de la phase alpha à bêta. L’outil est maintenant plus stable, fiable et sécurisé que jamais.
 

--- a/content/fr/blog/posts/illustrer-la-diversité-et-l’inclusion-pour-l’application-alerte-covid.md
+++ b/content/fr/blog/posts/illustrer-la-diversité-et-l’inclusion-pour-l’application-alerte-covid.md
@@ -15,6 +15,7 @@ image-alt: >-
   vêtements de différentes couleurs et se promenant.
 translationKey: blog-illustrating-covid-alert
 thumb: https://de2an9clyit2x.cloudfront.net/small_banner_covid_alert_illustration_7da49c6dc3.jpg
+tags: [""]
 ---
 Une application mobile sanitaire, qui se concentre sur un moment particulièrement difficile de notre vie, n’est pas toujours ce qu’il y a de plus agréable à construire — ou à utiliser.
 

--- a/content/fr/blog/posts/informer-pour-protéger-:-rappels-et-avis-de-sécurité-au-canada.md
+++ b/content/fr/blog/posts/informer-pour-protéger-:-rappels-et-avis-de-sécurité-au-canada.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/A_FR_Blog_Post_image_224f4374e1.jpg
 image-alt: Portrait d’Eric Chouinard, gestionnaire du projet de rappels et d’avis de sécurité à Santé Canada. Son entrevue est présentée au sein de la série « Les gens au cœur de vos services » du SNC. 
 thumb: https://de2an9clyit2x.cloudfront.net/small_A_FR_Blog_Post_image_224f4374e1.jpg
 translationKey: blog-pbs-series-eric
+tags: [""]
 ---
 Avez-vous pris connaissance du [récent rappel concernant les framboises](https://recalls-rappels.canada.ca/fr/avis-rappel/rappel-framboises-entieres-iqf-marque-below-zero-en-raison-presence-norovirus-1) ou celui [au mois d’avril concernant les produits Kinder](https://recalls-rappels.canada.ca/fr/avis-rappel/rappel-certains-produits-chocolat-marque-kinder-en-raison-presence-possible-0)?
 

--- a/content/fr/blog/posts/innover-à-la-fois-à-l’interne-et-à-l’externe-chez-edsc.md
+++ b/content/fr/blog/posts/innover-à-la-fois-à-l’interne-et-à-l’externe-chez-edsc.md
@@ -16,6 +16,7 @@ image-alt: >-
   bois.
 translationKey: innovating-esdc
 thumb: https://de2an9clyit2x.cloudfront.net/small_esdc_innovation_fr_c84ca9e64a.jpg
+tags: [""]
 ---
 À Emploi et Développement social Canada, nous avons vraiment commencé à embrasser l’idée d’être novateurs dans la façon dont nous fournissons des services et des informations à nos clients. Ce qui parfois nous semble plus difficile, c’est de nous ouvrir à de nouvelles façons de faire notre travail quotidien *à l’interne*.
 

--- a/content/fr/blog/posts/juste-assez-de-détails-concevoir-le-contenu-de-l’appli-alerte-covid.md
+++ b/content/fr/blog/posts/juste-assez-de-détails-concevoir-le-contenu-de-l’appli-alerte-covid.md
@@ -12,6 +12,7 @@ image-alt: >-
   passées dans un filtre, se transforment en deux lignes droites.
 translationKey: content-covidalert
 thumb: https://de2an9clyit2x.cloudfront.net/small_banner_content_covidalert_blog_198bc0a191.jpg
+tags: [""]
 ---
 Lorsque nous avons commencé à travailler sur [Alerte COVID](https://www.canada.ca/fr/sante-publique/services/maladies/maladie-coronavirus-covid-19/alerte-covid.html), nous savions [que l’une des clés du succès était la confiance](https://numerique.canada.ca/2020/10/02/d%C3%A9velopper-un-service-efficace-de-notification-dexposition-comme-alerte-covid/). Les gens n’allaient pas télécharger l’application s’ils n’y faisaient pas confiance. Et nous savions que la clé de la confiance était la compréhension.
 

--- a/content/fr/blog/posts/la-clé-c’est-la-communication-un-alphabet-radio-pour-alerte-covid.md
+++ b/content/fr/blog/posts/la-clé-c’est-la-communication-un-alphabet-radio-pour-alerte-covid.md
@@ -13,6 +13,7 @@ image-alt: >-
   un patient au téléphone.
 translationKey: phonetic-alphabet-blog
 thumb: https://de2an9clyit2x.cloudfront.net/small_banner_phonetic_alphabetic_blog_8f889946bb.jpg
+tags: [""]
 ---
 Le personnel du milieu de la santé ainsi que bien des agents administratifs jouent un rôle crucial dans la réussite de l’application Alerte COVID.
 

--- a/content/fr/blog/posts/la-fois-où-la-tenue-d’un-ama-a-ressemblé-à-une-course-à-relais.md
+++ b/content/fr/blog/posts/la-fois-où-la-tenue-d’un-ama-a-ressemblé-à-une-course-à-relais.md
@@ -16,6 +16,7 @@ image-alt: >-
   parallèles.
 translationKey: relay-race-ama
 thumb: https://de2an9clyit2x.cloudfront.net/small_ama_banner_032dcb83f7.jpg
+tags: [""]
 ---
 Imaginez que vous êtes le premier coureur d’une course à relais de 400 m. Vous vous placez en position de départ. On donne le signal, et vous vous lancez aussitôt dans un sprint en ne ménageant aucun effort. En vous approchant de la marque des 100 m, vous vous apercevez que personne n’est prêt à prendre le relais. Oh non! Vous devez maintenant continuer sur la même lancée et poursuivre ce sprint jusqu’à la fin de la course.
 

--- a/content/fr/blog/posts/la-masculinité-positive-ou-toxique-:-comment-les-hommes-peuvent-transformer-la-culture-organisationnelle.md
+++ b/content/fr/blog/posts/la-masculinité-positive-ou-toxique-:-comment-les-hommes-peuvent-transformer-la-culture-organisationnelle.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_positive_masculinity_intro_499c
 image-alt: Des gens aident à faire fleurir un jardin; certains retirent des plantes mortes et d’autres arrosent des plantes en croissance.
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_positive_masculinity_intro_499c43c730.jpg
 translationKey: blog-positive-masculinity-intro
+tags: [""]
 ---
 Autrefois, lorsque je visitais mon pays natal du Liban, mon grand-père me disait toujours « fiston, un homme bon c’est quelqu’un qui se trouve une épouse respectable, a des enfants et fournit tout le nécessaire à sa famille ». Mon père, à son tour, m’a répété les mêmes paroles à moi et à mes frères. Mes amis proches les ont aussi entendues. Ces paroles jettent les bases d’une dynamique où les hommes ont le pouvoir et le contrôle. C’est une dynamique qui peut parfois provoquer chez les hommes un sentiment de supériorité, donnant lieu au phénomène de mâle alpha qui ressent le besoin d’exercer sa domination, tant à la maison qu’au travail. 
 

--- a/content/fr/blog/posts/la-meilleure-attaque-de-panique-que-j’ai-jamais-eue.md
+++ b/content/fr/blog/posts/la-meilleure-attaque-de-panique-que-j’ai-jamais-eue.md
@@ -13,6 +13,7 @@ image-alt: >-
   panique.
 translationKey: best-panic-attack
 thumb: https://de2an9clyit2x.cloudfront.net/small_montreal_library_ec52e16559.jpg
+tags: [""]
 ---
 Il y a exactement un an, j’ai eu une crise de panique dans les toilettes de la Grande Bibliothèque à Montréal.
 

--- a/content/fr/blog/posts/la-phase-de-decouverte-comprendre-le-probleme.md
+++ b/content/fr/blog/posts/la-phase-de-decouverte-comprendre-le-probleme.md
@@ -17,6 +17,7 @@ image-alt: >-
   discutant de leur travail.
 translationKey: discovery-phase-understanding-the-problem
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_discovery_16d2f21c99.jpg
+tags: [""]
 ---
 
 Les anciens combattants ont consacré leur vie à servir le Canada. Que ce soit à la Gendarmerie royale du Canada ou aux Forces armées canadiennes, quitter le service, c’est comme quitter une famille et un emploi en même temps. Dans cette nouvelle phase de leur vie, les anciens combattants font face à de nombreux défis qui sont très différents du stress physique et psychologique qu’ils subissaient chaque jour alors qu’ils portaient l’uniforme. L’un des nombreux importants défis consiste à comprendre les plus de prestations et services qui leur sont offerts, et à y accéder.

--- a/content/fr/blog/posts/la-sécurité-c’est-difficile-mais-c’est-aussi-nécessaire-et-gérable.md
+++ b/content/fr/blog/posts/la-sécurité-c’est-difficile-mais-c’est-aussi-nécessaire-et-gérable.md
@@ -10,6 +10,7 @@ image-alt: >-
   programmes.
 translationKey: security-hard
 thumb: https://de2an9clyit2x.cloudfront.net/small_airplane_460f30dd8a.jpg
+tags: [""]
 ---
 La sécurité numérique, c’est difficile. Même les meilleures équipes d’ingénieurs et de spécialistes des TI sont susceptibles de faire des erreurs à un moment donné. Mais tout comme la sécurité dans les aéroports, les étapes et les processus en place sont là pour votre sûreté.
 

--- a/content/fr/blog/posts/la-sécurité-c’est-sérieux-nous-avons-tous-des-clés-de-sécurité-au-snc.md
+++ b/content/fr/blog/posts/la-sécurité-c’est-sérieux-nous-avons-tous-des-clés-de-sécurité-au-snc.md
@@ -11,6 +11,7 @@ image: https://de2an9clyit2x.cloudfront.net/yubikey_3_f8e7460aeb.jpg
 image-alt: Une main qui appuie sur sa clé yubikey.
 translationKey: yubikey-post
 thumb: https://de2an9clyit2x.cloudfront.net/small_yubikey_3_f8e7460aeb.jpg
+tags: [""]
 ---
 J’ai peur, très peur! J’ai peur de me réveiller le matin et de constater que les ressources infonuagiques du Service numérique canadien (SNC) ont été vandalisées ou détruites parce qu’une personne mal intentionnée a mis la main sur les justificatifs d’identité de quelqu’un et a décidé de tout bousiller. Cette peur est réelle, et même les plus consciencieux d’entre nous sont vulnérables.
 

--- a/content/fr/blog/posts/la-valeur-d’une-pause-:-histoires-de-changement-à-la-grc.md
+++ b/content/fr/blog/posts/la-valeur-d’une-pause-:-histoires-de-changement-à-la-grc.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_pause_rcmp_57c7e7d485.jpeg
 image-alt: Quatre blocs de bois affichant un symbole de pause.
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_pause_rcmp_57c7e7d485.jpeg
 translationKey: blog-rcmp-most-significant-change
+tags: [""]
 ---
 « La vie va assez vite. Si vous ne vous arrêtez pas de temps en temps pour l’apprécier, vous pourriez tout rater. » - Ferris Bueller
 

--- a/content/fr/blog/posts/lacunes-linguistiques.md
+++ b/content/fr/blog/posts/lacunes-linguistiques.md
@@ -14,6 +14,7 @@ image-alt: >-
   portables.
 translationKey: language-gap
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_language_gap_72a7c0e138.jpg
+tags: [""]
 ---
 
 Lorsque nous optons pour des outils de source libre (*open source*), l’un des plus grands obstacles que nous rencontrons est la langue, ou plutôt l’absence de la langue française. L’adaptation d’une application à la langue locale s’appelle l’internationalisation, ou [i18n](https://fr.wikipedia.org/wiki/Internationalisation_(informatique)) en forme abrégée. Au Canada, nous avons le défi d’offrir une expérience soutenue et accessible autant en français qu'en anglais, nos deux langues officielles. Les technologies modernes sont formidables, mais le monde de la technologie est manifestement unilingue anglais. De nombreux outils de source libre n’offrent pas la fonction multilingue dont nous avons besoin, comme la capacité de changer une version du contenu en contexte. Comment comblons-nous donc ce fossé afin d’offrir des services modernes aux Canadiens?

--- a/content/fr/blog/posts/lancement-du-service-numerique-canadien.md
+++ b/content/fr/blog/posts/lancement-du-service-numerique-canadien.md
@@ -14,6 +14,7 @@ image: https://de2an9clyit2x.cloudfront.net/launch_post_2017_f32b0ac0bf.jpg
 image-alt: 'L''honorable Scott Brison, Président du Conseil du Trésor'
 translationKey: launch-of-the-canadian-digital-service
 thumb: https://de2an9clyit2x.cloudfront.net/small_launch_post_2017_f32b0ac0bf.jpg
+tags: [""]
 ---
 Les Canadiens méritent des services gouvernementaux accessibles et faciles à utiliser. Ils s’attendent à ce que leur gouvernement fournisse des services axés sur les citoyens. Dans ce monde hyper connecté du 21<sup>e</sup> siècle, un service de qualité entend la prestation numérique, qu’il s’agisse de commander un mets à emporter, de renouveler son hypothèque, de gérer ses ordonnances ou d’accéder à des programmes et services gouvernementaux.
 

--- a/content/fr/blog/posts/lancement-d’un-service-alpha.md
+++ b/content/fr/blog/posts/lancement-d’un-service-alpha.md
@@ -16,6 +16,7 @@ image-alt: >-
   COVID-19» sur son téléphone mobile.
 translationKey: get-updates-blog-2
 thumb: https://de2an9clyit2x.cloudfront.net/small_get_updates_c19_phone_fr_963f308dbc.jpg
+tags: [""]
 ---
 *Marcel Saulnier et Jennifer Hollington sont tous deux sous-ministres adjoints à Santé Canada. M. Saulnier a supervisé la conception et le lancement du service de notification par courriel « [Obtenir les nouvelles sur la COVID-19](https://www.canada.ca/covid19nouvelles) » dans le cadre de sa participation au groupe de travail sur la COVID-19. L’équipe des communications de Mme Hollington a repris le service alors que celui-ci s’inscrit dans la fonction de communication de Santé Canada.*
 

--- a/content/fr/blog/posts/langage-inclusif-au-travail-:-mieux-choisir-nos-mots.md
+++ b/content/fr/blog/posts/langage-inclusif-au-travail-:-mieux-choisir-nos-mots.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/word_bubbles_0d3d2006c1.jpg
 image-alt: Bulles de dialogue de différentes couleurs se chevauchant.
 thumb: https://de2an9clyit2x.cloudfront.net/small_word_bubbles_0d3d2006c1.jpg
 translationKey: blog-inclusive-words
+tags: [""]
 ---
 Les mots comptent. C’est on ne peut plus vrai en matière de conception de services. Ici, au Service numérique canadien (SNC), nous cherchons à utiliser des mots de tous les jours. Cela contribue à rendre nos services plus inclusifs et plus compréhensibles.
 

--- a/content/fr/blog/posts/le-bon-le-méchant-et-la-lutte-récapitulation-de-la-semaine-de-la-décentralisation-du-snc.md
+++ b/content/fr/blog/posts/le-bon-le-méchant-et-la-lutte-récapitulation-de-la-semaine-de-la-décentralisation-du-snc.md
@@ -14,6 +14,7 @@ image-alt: >-
   Charlotte.
 translationKey: CDS-distributed
 thumb: https://de2an9clyit2x.cloudfront.net/small_google_hangout_9039889404.jpg
+tags: [""]
 ---
 Au cours de la dernière année, le Service numérique canadien (SNC) a pris une expansion considérable. Il compte maintenant des collègues à Ottawa, à Toronto, à Montréal et à Kitchener-Waterloo. Bien que notre bureau à Ottawa compte le plus grand nombre d’employés, nous sommes un organisme géographiquement dispersé. Nous travaillons dans un environnement où tout le monde, peu importe leur emplacement géographique, est en mesure de contribuer aux objectifs de l’équipe de la même façon que le fait une équipe dont les membres travaillent tous dans le même bureau.
 

--- a/content/fr/blog/posts/le-point-sur-notre-demande-de-propositions.md
+++ b/content/fr/blog/posts/le-point-sur-notre-demande-de-propositions.md
@@ -8,6 +8,7 @@ image: https://de2an9clyit2x.cloudfront.net/rfp_fr_3ac06f0e03.jpg
 image-alt: 'Des autocollants en forme de feuilles d''érables avec les mots, fort et libre.'
 translationKey: update-rfp
 thumb: https://de2an9clyit2x.cloudfront.net/small_rfp_fr_3ac06f0e03.jpg
+tags: [""]
 ---
 Nous tenons à remercier tous les soumissionnaires qui ont consacré le temps et les efforts nécessaires pour répondre à notre [demande de propositions](https://achatsetventes.gc.ca/donnees-sur-l-approvisionnement/appels-d-offres/PW-18-00841347). Depuis que le processus de demande de propositions a pris fin, nous travaillons sans relâche à l’évaluation des soumissions, mais cela prend plus de temps que nous l’aurions souhaité. Nous savons que vous et vos équipes devez établir des plans. Cela dit, voici une mise à jour sur le calendrier le plus plausible et quelques rappels :
 

--- a/content/fr/blog/posts/le-problème-inattendu-de-l’infolettre-française.md
+++ b/content/fr/blog/posts/le-problème-inattendu-de-l’infolettre-française.md
@@ -14,6 +14,7 @@ image-alt: >-
   mot « sondage », un sablier et une bulle de texte avec un bonhomme sourire.
 translationKey: french-newsletter-surveys
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_newsletter_testing_a152e66ccb.jpg
+tags: [""]
 ---
 <div class="blog-diary">
 

--- a/content/fr/blog/posts/le-recrutement-de-notre-dirigeant-principal.md
+++ b/content/fr/blog/posts/le-recrutement-de-notre-dirigeant-principal.md
@@ -9,6 +9,7 @@ image-alt: >-
   l’équipe.
 translationKey: recruiting-our-ceo
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_ceo_recruitment_883dc9d347.jpg
+tags: [""]
 ---
 
 Nous avons récemment [annoncé](https://numerique.canada.ca/2018/03/09/le-snc-accueille-son-premier-dirigeant-principal/) qu’Aaron Snow se joignait au Service numérique canadien (SNC) en tant que premier dirigeant principal pour faire partie de notre mouvement numérique.

--- a/content/fr/blog/posts/le-renforcement-des-environnements-inclusifs-commence-par-celui-de-la-communauté-et-pour-vous-aider-à-débuter-nous-avons-créé-un-guide-sur-l’accessibilité.md
+++ b/content/fr/blog/posts/le-renforcement-des-environnements-inclusifs-commence-par-celui-de-la-communauté-et-pour-vous-aider-à-débuter-nous-avons-créé-un-guide-sur-l’accessibilité.md
@@ -18,6 +18,7 @@ image-alt: >-
   Julianna Rowsell, posant devant un mur mauve.
 translationKey: accessibility-handbook
 thumb: https://de2an9clyit2x.cloudfront.net/small_accessibility_handbook_blog_00d02c5777.jpg
+tags: [""]
 ---
 Dix ans! Cela fait 10 ans que je travaille dans le domaine de l’accessibilité au sein de la fonction publique. J’ai vu notre communauté évoluer et changer à mesure que de nouveaux visages sont arrivés et sont repartis. Bon nombre des personnes qui s’occupaient de l’accessibilité dans la fonction publique lorsque j’ai commencé en sont encore aujourd’hui les fers de lance. Notre communauté est petite, mais robuste, et elle travaille à la croisée des ministères et des secteurs afin d’améliorer l’accès aux services pour les gens.
 

--- a/content/fr/blog/posts/les-choix-technologiques-du-snc.md
+++ b/content/fr/blog/posts/les-choix-technologiques-du-snc.md
@@ -19,6 +19,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_technology_choices_at_cds_2017_
 image-alt: Un écran d'ordinateur montrant les résultats d'une série de tests.
 translationKey: technology-choices-at-cds
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_technology_choices_at_cds_2017_7fc41ef768.jpg
+tags: [""]
 ---
 Il y a quelques semaines, nous avons lancé notre [campagne de recrutement publique](/carrieres/) dans le but d’embaucher des concepteurs, des développeurs, des scientifiques de données, des gestionnaires de produits et des experts en mobilisation. S’informant au sujet du volet des développeurs, certains nous ont demandé avec quelles plateformes technologiques et quels langages de programmation nous travaillons. Excellente question! L’un des aspects excitants de vous joindre au Service numérique canadien (SNC) si tôt dans notre existence est que vous aurez la chance de modeler la façon dont nos choix technologiques évoluent. Dans cet esprit, c’est-à-dire qu’aucune de ces technologies n’est définitive, j’ai pensé faire le point sur le raisonnement de notre équipe de développement à ce jour ainsi que sur les deux objectifs (en opposition) qui influencent nos choix technologiques.
 

--- a/content/fr/blog/posts/les-réponses-à-vos-questions-sur-notre-nouvelle-plateforme-d’envoi-de-courriels-et-de-textos-gouvernementaux.md
+++ b/content/fr/blog/posts/les-réponses-à-vos-questions-sur-notre-nouvelle-plateforme-d’envoi-de-courriels-et-de-textos-gouvernementaux.md
@@ -20,6 +20,7 @@ image-alt: >-
   texte envoyés grâce au service Notification.
 translationKey: notify-blog2
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_notify2_89a385e31d.jpg
+tags: [""]
 ---
 *Mise à jour : Comme tout produit numérique, Notification GC fait l’objet d’améliorations constantes pour répondre aux besoins d’équipes issues de l’ensemble du gouvernement.* *Pour obtenir les derniers renseignements en date, veuillez vous référer à la page consacrée aux [fonctionnalités de Notification GC](https://notification.canada.ca/fonctionnalites).*
 

--- a/content/fr/blog/posts/les-rétrospectives-inclusives-:-dix-conseils-pour-devenir-une-meilleure-équipe!.md
+++ b/content/fr/blog/posts/les-rétrospectives-inclusives-:-dix-conseils-pour-devenir-une-meilleure-équipe!.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/fr_banner_blog_retro_facilitation_ti
 image-alt: Un tableau d’activités de rétrospective avec des plantes qui poussent à la surface. Texte : Conseils de rétrospective pour améliorer l’équipe .
 thumb: https://de2an9clyit2x.cloudfront.net/small_fr_banner_blog_retro_facilitation_tips_f2c659f9df.jpg
 translationKey: blog-retro-facilitation-tips
+tags: [""]
 ---
 Faites-vous des rétrospectives avec votre équipe? 
 

--- a/content/fr/blog/posts/les-tests-automatises.md
+++ b/content/fr/blog/posts/les-tests-automatises.md
@@ -18,6 +18,7 @@ image-alt: >-
   face d’elle qui montre un signe d’accord.
 translationKey: automated-testing-blog
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_automated_testing_76c2e620d6.jpg
+tags: [""]
 ---
 
 Dans le cadre de l’interface de programmation d’applications (API) développée avec Ressources naturelles Canada (RNCan), nous suivons un processus commun d’intégration continue (IC), qui comprend l’utilisation intensive de tests automatisés. À notre avis, les tests d’IC et les tests automatisés constituent une condition fondamentale à la production et au maintien de produits logiciels de haute qualité.

--- a/content/fr/blog/posts/lexique.md
+++ b/content/fr/blog/posts/lexique.md
@@ -13,6 +13,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_lexicon_8af48d9cd5.jpg
 image-alt: Une illustration d’un combo laveuse-sécheuse.
 translationKey: lexicon
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_lexicon_8af48d9cd5.jpg
+tags: [""]
 ---
 
 ## Pourquoi un lexique?

--- a/content/fr/blog/posts/libérer-le-talent et-4-autres-conseils-pour-changer-le-gouvernement.md
+++ b/content/fr/blog/posts/libérer-le-talent et-4-autres-conseils-pour-changer-le-gouvernement.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/nordwood_themes_1066398_unsplash_390
 image-alt: '2019 écrit en feux d''artifices, Photo : NordWood Themes/Unsplash'
 translationKey: unleash-talent
 thumb: https://de2an9clyit2x.cloudfront.net/small_nordwood_themes_1066398_unsplash_390a276ba7.jpg
+tags: [""]
 ---
 Après deux ans à bâtir le SNC, j’ai voulu partager quelques réflexions sur ce que j’ai appris. Avec l’aide de nos partenaires, nous changeons la façon dont le gouvernement conçoit et livre ses services. Néanmoins, le chemin à parcourir est long. Voici ce qui nous permettra d’y arriver :
 

--- a/content/fr/blog/posts/l’accord-parfait-quand-les-politiques-renforcent-la-recherche-en-conception.md
+++ b/content/fr/blog/posts/l’accord-parfait-quand-les-politiques-renforcent-la-recherche-en-conception.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/tim_swaan_45717_unsplash_e218e3ac92.
 image-alt: Une passerelle qui mène vers une forêt.
 translationKey: user-interview-policy
 thumb: https://de2an9clyit2x.cloudfront.net/small_tim_swaan_45717_unsplash_e218e3ac92.jpg
+tags: [""]
 ---
 Si vous êtes un fonctionnaire et que vous souhaitez mener des entrevues auprès des gens qui utilisent votre service, ce billet est pour vous. Dans tout secteur, il peut déjà être difficile de recruter des personnes à des fins de recherche en conception de services. Le gouvernement, toutefois, a des exigences supplémentaires. Bien que certaines d’entre elles soient justifiées par sa position en tant qu’autorité, [d’autres peuvent découler d’une culture ou d’habitudes](https://numerique.canada.ca/2018/09/07/politiques/). Dans ce billet, nous vous montrons comment nous avons fait pour recruter des anciens combattants et mener notre recherche.
 

--- a/content/fr/blog/posts/mesurer-l’impact-d’alerte-covid-grâce-aux-mesures-de-perf.md
+++ b/content/fr/blog/posts/mesurer-l’impact-d’alerte-covid-grâce-aux-mesures-de-perf.md
@@ -18,6 +18,7 @@ image-alt: >-
   d’eux.
 translationKey: blog-metrics-app
 thumb: https://de2an9clyit2x.cloudfront.net/small_metrics_covid_alert_blog_banner_d83e1f15da.jpg
+tags: [""]
 ---
 Le changement est la seule constante, surtout en cas de pandémie. Comme la plupart des gens, j’ai dû m’habituer à un style de vie différent. Alors qu’autrefois je parcourais le Grand Toronto pour écouter des groupes méconnus dans des salles de spectacle insolites, je m’installe maintenant dans mon salon pour lire des romans de Margaret Atwood. Mes samedis sont très différents.
 

--- a/content/fr/blog/posts/mode-multijoueur-débloqué-une-meilleure-collaboration-entre-concepteurs-développeurs-et-chercheurs.md
+++ b/content/fr/blog/posts/mode-multijoueur-débloqué-une-meilleure-collaboration-entre-concepteurs-développeurs-et-chercheurs.md
@@ -17,6 +17,7 @@ image-alt: >-
   à l’effigie du SNC.
 translationKey: multiplayer-figma
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_multiplayer_figma_4b3304945a.jpg
+tags: [""]
 ---
 Bon nombre de jeux sont plus amusants à jouer en mode multijoueur qu’en solo. Vous verriez-vous jouer au basketball tout seul? Plutôt ennuyeux, n’est-ce pas?
 

--- a/content/fr/blog/posts/modification-de-notre-approche-aux-partenariats.md
+++ b/content/fr/blog/posts/modification-de-notre-approche-aux-partenariats.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/banner_pivoting_partnerships_d296e0d
 image-alt: Un réseau interconnecté montrant des personnes de tout le Canada qui collaborent pour offrir des services numériques et qui mettent les gens au cœur de leur travail..
 thumb: https://de2an9clyit2x.cloudfront.net/small_banner_pivoting_partnerships_d296e0dc14.jpg
 translationKey: blog-pivoting-partnerships
+tags: [""]
 ---
 Il y a cinq ans, nous avons annoncé le [lancement du Service numérique canadien](https://numerique.canada.ca/2017/07/18/lancement-du-service-numerique-canadien/)  (SNC). Il s’agissait alors d’un projet pilote de trois ans avec pour mission d’aider à moderniser la façon dont le gouvernement du Canada concevait et fournissait ses services numériques. Depuis lors, nous avons beaucoup appris et [grandi](https://numerique.canada.ca/rencontrez-lequipe/). L’an dernier, nous avons obtenu un financement permanent par le biais du budget pour l’année 2021. Nous pouvons donc continuer à collaborer avec les équipes gouvernementales et offrir des services pangouvernementaux comme [Notification GC](https://notification.canada.ca/accueil), tout en ayant l’assurance que nous serons toujours là pour les entretenir et les améliorer.
 

--- a/content/fr/blog/posts/montrer-liceberg-en-entier.md
+++ b/content/fr/blog/posts/montrer-liceberg-en-entier.md
@@ -14,6 +14,7 @@ image-alt: >-
   dans un aquarium, alors qu’un petit chien observe.
 translationKey: showing-the-whole-iceberg
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_iceberg_header_9690f17788.jpg
+tags: [""]
 ---
 
 *« Je crois que les équipes comme le SNC sont des équipes de gestion du changement déguisés en équipes de services numériques. »* – Aaron Snow, dirigeant principal

--- a/content/fr/blog/posts/notre-partenariat-avec-code-for-canada.md
+++ b/content/fr/blog/posts/notre-partenariat-avec-code-for-canada.md
@@ -13,6 +13,7 @@ image-alt: >-
   l’extérieur de l’édifice du parlement provincial à Toronto.
 translationKey: our-partnership-with-code-for-canada
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_c4c_26d807bbf1.jpg
+tags: [""]
 ---
 
 L’automne dernier, nous avons accueilli l’une des deux premières cohortes d’associés de [Code for Canada](https://codefor.ca/fr/) (C4C), l’autre s’étant jointe à nos collègues du gouvernement de l’Ontario. Ce billet de blogue décrira comment tirer le meilleur parti d’un partenariat potentiel!

--- a/content/fr/blog/posts/nous-aimons-les-bons-défis.md
+++ b/content/fr/blog/posts/nous-aimons-les-bons-défis.md
@@ -13,6 +13,7 @@ image-alt: >-
   affichant « FWD50 », et un écran à l’avant indique « Défi accepté ».
 translationKey: we-love-a-good-challenge
 thumb: https://de2an9clyit2x.cloudfront.net/small_aaron_fwd50_challenge_accepted_fr_5d443a19c9.jpg
+tags: [""]
 ---
 L’été dernier, le gouvernement fédéral a réuni des chefs de file de l’industrie canadienne pour aider à orienter les [stratégies économiques du Canada](https://www.ic.gc.ca/eic/site/098.nsf/fra/accueil). L’un de ces groupes, soit la Table sur les industries numériques qui était présidée par le président-directeur général de Shopify, [Tobi Lütke](https://twitter.com/tobi), a examiné la façon dont le Canada pourrait devenir un chef de file du numérique. Son rapport, publié en septembre 2018, [présente une vision audacieuse](https://www.ic.gc.ca/eic/site/098.nsf/vwapj/ISEDC_IndustriesNumeriques.pdf/%24file/ISEDC_IndustriesNumeriques.pdf) du Canada en tant que société numérique.
 

--- a/content/fr/blog/posts/nous-lançons-un-accélérateur-pour-tester-l’investissement-progressif.md
+++ b/content/fr/blog/posts/nous-lançons-un-accélérateur-pour-tester-l’investissement-progressif.md
@@ -11,6 +11,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_up_to_speed_030a3f5cc5.jpg
 image-alt: Indicateur de vitesse
 translationKey: accelerator-launch
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_up_to_speed_030a3f5cc5.jpg
+tags: [""]
 ---
 La collaboration avec le secteur privé joue un rôle important dans les pays qui font de grands progrès en matière de gouvernement numérique. Le gouvernement ne peut pas y arriver seul. La passation de marchés contribue à l’expansion des technologies modernes et des méthodes de conception dans le secteur public. Les entreprises apportent une expertise spécialisée, une capacité d’intensification flexible, une envergure et une expérience à la fine pointe de la technologie et de la pratique.
 

--- a/content/fr/blog/posts/nous-sommes-tous-concernes.md
+++ b/content/fr/blog/posts/nous-sommes-tous-concernes.md
@@ -7,6 +7,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_in_this_together_2017_082de0960
 image-alt: L’équipe des Services numériques de l’Ontario.
 translationKey: n-this-together
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_in_this_together_2017_082de0960c.jpg
+tags: [""]
 ---
 Il y a environ un mois, j’ai eu la chance de participer à la [conférence Connected150](http://www.connected150.ca) et de passer un peu de temps avec nos collègues du Service numérique canadien (SNC).
 

--- a/content/fr/blog/posts/obtenir-les-nouvelles-sur-la-covid-19-—-service-de-notification-par-courriel.md
+++ b/content/fr/blog/posts/obtenir-les-nouvelles-sur-la-covid-19-—-service-de-notification-par-courriel.md
@@ -13,6 +13,7 @@ image-alt: >-
   «Obtenir les nouvelles sur la COVID-19» sur son téléphone.
 translationKey: blog-get-covid-updates
 thumb: https://de2an9clyit2x.cloudfront.net/small_financial_help_covid_19_fr_d69ae8d21c.jpg
+tags: [""]
 ---
 **« Le numérique consiste à appliquer la culture, les processus, les modèles d’affaires et les technologies de l’ère de l’Internet pour répondre aux attentes élevées des personnes. » – Tom Loosemore**
 

--- a/content/fr/blog/posts/obtenir-un-wi-fi-externe-dans-les-bureaux-du-gouvernement.md
+++ b/content/fr/blog/posts/obtenir-un-wi-fi-externe-dans-les-bureaux-du-gouvernement.md
@@ -12,6 +12,7 @@ image: https://de2an9clyit2x.cloudfront.net/img_20190206_121320_bceaa8ad84.jpg
 image-alt: Une personne raccorde son Macbook à un appareil MiFi portatif.
 translationKey: external-wifi
 thumb: https://de2an9clyit2x.cloudfront.net/small_img_20190206_121320_bceaa8ad84.jpg
+tags: [""]
 ---
 Le fait d’avoir accès à des outils modernes est une condition préalable pour la prestation de services numériques modernes. Nous avons écrit auparavant au sujet de [l’importance des outils modernes](https://numerique.canada.ca/2018/06/27/outils-pour-faire-du-bon-travail/), tels que des MacBook et des ordinateurs portables basés sur Linux, pour la conception et le développement de logiciels.
 

--- a/content/fr/blog/posts/on-s’en-sort-avec-l’aide-de-nos-amis.md
+++ b/content/fr/blog/posts/on-s’en-sort-avec-l’aide-de-nos-amis.md
@@ -13,6 +13,7 @@ image-alt: Deux vieux Volkswagen Beetles se font face dans un champ sous un ciel
 translationKey: help-from-friends
 thumb: https://de2an9clyit2x.cloudfront.net/small_katka_pavlickova_131100_unsplash_min_3c6c37adef.jpg
 tags: [""]
+
 ---
 Des collègues fonctionnaires me demandent souvent « Quelles autorisations le Service numérique canadien (SNC) a-t-il obtenues pour fonctionner comme il le fait ? » J’ai donc pensé vous faire part des autorisations que nous avons reçues du gouvernement quand le SNC a été fondé en 2017:
 

--- a/content/fr/blog/posts/on-s’en-sort-avec-l’aide-de-nos-amis.md
+++ b/content/fr/blog/posts/on-s’en-sort-avec-l’aide-de-nos-amis.md
@@ -13,7 +13,6 @@ image-alt: Deux vieux Volkswagen Beetles se font face dans un champ sous un ciel
 translationKey: help-from-friends
 thumb: https://de2an9clyit2x.cloudfront.net/small_katka_pavlickova_131100_unsplash_min_3c6c37adef.jpg
 tags: [""]
-
 ---
 Des collègues fonctionnaires me demandent souvent « Quelles autorisations le Service numérique canadien (SNC) a-t-il obtenues pour fonctionner comme il le fait ? » J’ai donc pensé vous faire part des autorisations que nous avons reçues du gouvernement quand le SNC a été fondé en 2017:
 

--- a/content/fr/blog/posts/on-s’en-sort-avec-l’aide-de-nos-amis.md
+++ b/content/fr/blog/posts/on-s’en-sort-avec-l’aide-de-nos-amis.md
@@ -12,6 +12,7 @@ image: https://de2an9clyit2x.cloudfront.net/katka_pavlickova_131100_unsplash_min
 image-alt: Deux vieux Volkswagen Beetles se font face dans un champ sous un ciel bleu.
 translationKey: help-from-friends
 thumb: https://de2an9clyit2x.cloudfront.net/small_katka_pavlickova_131100_unsplash_min_3c6c37adef.jpg
+tags: [""]
 ---
 Des collègues fonctionnaires me demandent souvent « Quelles autorisations le Service numérique canadien (SNC) a-t-il obtenues pour fonctionner comme il le fait ? » J’ai donc pensé vous faire part des autorisations que nous avons reçues du gouvernement quand le SNC a été fondé en 2017:
 

--- a/content/fr/blog/posts/on-vous-présente-notification.md
+++ b/content/fr/blog/posts/on-vous-présente-notification.md
@@ -14,6 +14,7 @@ image-alt: >-
   l’autre en français.
 translationKey: introducing-notify
 thumb: https://de2an9clyit2x.cloudfront.net/small_introducing_notify_d264bc51ad.jpg
+tags: [""]
 ---
 Imaginez un scénario où chaque fois que vous utilisez un service gouvernemental, toute l’information nécessaire est acheminée au bon destinataire, au bon moment, et vous en avez l’assurance du début à la fin. Ces derniers mois, nous avons consacré notre temps à élaborer une solution qui aiderait le gouvernement du Canada à atteindre cet objectif.
 

--- a/content/fr/blog/posts/outils-pour-faire-du-bon-travail.md
+++ b/content/fr/blog/posts/outils-pour-faire-du-bon-travail.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_tools_for_work_2018_15b0dcce32.
 image-alt: Plusieurs ordinateurs MacBook couverts d'autocollants sur une table.
 translationKey: tools-to-do-good-work
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_tools_for_work_2018_15b0dcce32.jpg
+tags: [""]
 ---
 
 Nous avons déjà blogué sur l’importance des [tests automatisés](https://numerique.canada.ca/2018/03/26/les-tests-automatises/), de [l’intégration continue](https://numerique.canada.ca/2018/05/16/reduire-le-risque-grace-au-deploiement-continu/), et certains de nos premiers [choix de plateformes technologiques](https://numerique.canada.ca/2017/11/06/les-choix-technologiques-du-snc/). Afin d’adopter des pratiques numériques modernes, il est également important d’avoir les outils – à la fois les appareils et les logiciels – qui rendent cela possible.

--- a/content/fr/blog/posts/parler-numerique-en-francais.md
+++ b/content/fr/blog/posts/parler-numerique-en-francais.md
@@ -14,6 +14,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_discussing_digital_in_french_20
 image-alt: Clavier d’ordinateur avec une touche illustrant le drapeau de la France.
 translationKey: discussing-digital-in-french
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_discussing_digital_in_french_2017_0d1d34a4de.jpg
+tags: [""]
 ---
 Demain, le 30 septembre, ce sera la Journée mondiale de la traduction. Pour moi, parler du numérique en français, c’est un défi&nbsp;: Nommer correctement les nouveautés technologiques et *surtout* – surtout – ne pas perdre de vue que nous nous adressons à «&nbsp;du vrai monde&nbsp;». **Penser à l’utilisateur d’abord, le placer au cœur de notre travail, c’est aussi dans les mots que nous choisissons**.
 

--- a/content/fr/blog/posts/parlons-de-l’expérience-utilisateur:-s’éloigner-des-pixels-se-tourner-vers-les-gens".md
+++ b/content/fr/blog/posts/parlons-de-l’expérience-utilisateur:-s’éloigner-des-pixels-se-tourner-vers-les-gens".md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_user_experience_7e314a7e97.jpg
 image-alt: Trois membres de l'équipe du SNC présentent un atelier avec du personnel de IRCC à Vancouver. Deux d'entre eux figurent dans l'image. Ils travaillent ensemble pour écrire des idées sur des notes auto-collantes et ils les placent dans un des quatre quadrants sur le mur.
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_user_experience_7e314a7e97.jpg
 translationKey: lets-talk-user-experience
+tags: [""]
 ---
 ![ux-drawing.jpg](https://de2an9clyit2x.cloudfront.net/ux_drawing_3c85289fc0.jpg)
 

--- a/content/fr/blog/posts/politiques.md
+++ b/content/fr/blog/posts/politiques.md
@@ -7,6 +7,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_puzzle_19c62eec59.jpg
 image-alt: Morceaux de casse-tête de couleurs différentes connectés ensemble.
 translationKey: policy
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_puzzle_19c62eec59.jpg
+tags: [""]
 ---
 Au sein du Service numérique canadien, nous avons eu la chance d'apprendre de plusieurs grands modèles du Royaume-Uni, des États-Unis, de l'Italie, de l'Australie, de l'Ontario et de bien d'autres endroits, alors que nous travaillons avec nos partenaires pour améliorer les services numériques offerts aux Canadiens et aux Canadiennes. Nous utilisons des techniques bien établies pour diriger cette mission : regrouper des talents multidisciplinaires en équipes qui s'attaquent ensemble aux questions de service. Nos équipes de produits sont composées de concepteurs, de chercheurs, de développeurs et de gestionnaires de produit, puis nous avons également intégré des spécialistes en politiques et communications.
 

--- a/content/fr/blog/posts/pourquoi-canada-a-besoin-service-numerique.md
+++ b/content/fr/blog/posts/pourquoi-canada-a-besoin-service-numerique.md
@@ -15,6 +15,7 @@ image-alt: >-
   Elvas
 translationKey: why-canada-needs-a-digital-service
 thumb: https://de2an9clyit2x.cloudfront.net/small_why_canada_needs_a_digital_service_2017_83f1ff7d59.jpg
+tags: [""]
 ---
 Pendant plusieurs mois, j’ai travaillé en coulisses pour défendre cette cause qu’est le Service numérique canadien (SNC). J’ai beaucoup réfléchi à la raison d’être d’une organisation dédiée aux services numériques au Canada, ainsi qu’au potentiel de cette organisation de changer la façon de concevoir les services gouvernementaux.
 

--- a/content/fr/blog/posts/pourquoi-le-code-source-libre-est-il-important.md
+++ b/content/fr/blog/posts/pourquoi-le-code-source-libre-est-il-important.md
@@ -14,6 +14,7 @@ image-alt: >-
   une maison au moyen de différents blocs.
 translationKey: why-open-source-matters
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_open_source_b720f5ece8.jpg
+tags: [""]
 ---
 Il y a quelques semaines, nous avons publié un [fil Twitter](https://twitter.com/SNC_GC/status/1227970738017251335) sur ce qu’est le code source libre et sur la façon dont il améliore les services en ligne. Nous avons reçu beaucoup de questions à ce sujet de partout au gouvernement. Utiliser du code source libre — et publier le code logiciel que nous écrivons — constitue l’un des principes les plus importants au Service numérique canadien. Si vous êtes curieux de savoir pourquoi, poursuivez votre lecture!
 

--- a/content/fr/blog/posts/pouvez-vous-encadrer-la-communauté-de-développeurs-logiciel-du-snc.md
+++ b/content/fr/blog/posts/pouvez-vous-encadrer-la-communauté-de-développeurs-logiciel-du-snc.md
@@ -16,6 +16,7 @@ image-alt: >-
   réunion
 translationKey: blog-head-software-dev
 thumb: https://de2an9clyit2x.cloudfront.net/blog_head_software_dev_4d582ff210.jpg
+tags: [""]
 ---
 Le gouvernement numérique et les associations de technologie civique parlent beaucoup de la façon d’habiliter le gouvernement à fournir des services révolutionnaires. Des éléments comme les pratiques agiles, la réflexion conceptuelle et l’utilisation des technologies modernes sont monnaie courante. Au Service numérique canadien (SNC), nous croyons à l’importance de « donner la priorité aux personnes ». C’est pourquoi embaucher la bonne personne est important, voire plus important que ces processus et outils.
 

--- a/content/fr/blog/posts/prêcher-par-l’exemple-une-rencontre-avec-notre-partenaire-de-la-grc.md
+++ b/content/fr/blog/posts/prêcher-par-l’exemple-une-rencontre-avec-notre-partenaire-de-la-grc.md
@@ -16,6 +16,7 @@ image-alt: >-
   de tourner les coins ronds. Il s’agit d’emprunter un chemin différent. »
 translationKey: jeff-adam-interview
 thumb: https://de2an9clyit2x.cloudfront.net/small_jeff_adam_9fda86899c.jpg
+tags: [""]
 ---
 En 1987, Jeff Adam s’est joint à la Gendarmerie royale du Canada (GRC) parce qu’il voulait aider les personnes vulnérables et attraper les méchants. Trente-trois ans plus tard, il s’efforce toujours de le faire, maintenant en tant que commissaire adjoint chargé des opérations techniques.
 

--- a/content/fr/blog/posts/recherche-dirigeant-principal-du-service-numerique-canadien.md
+++ b/content/fr/blog/posts/recherche-dirigeant-principal-du-service-numerique-canadien.md
@@ -14,6 +14,7 @@ image: https://de2an9clyit2x.cloudfront.net/wanted_ceo_cds_2017_992dcbf98e.jpg
 image-alt: 'Yaprak Baltacıoğlu, Secrétaire du Conseil du Trésor'
 translationKey: wanted-ceo-cds
 thumb: https://de2an9clyit2x.cloudfront.net/small_wanted_ceo_cds_2017_992dcbf98e.jpg
+tags: [""]
 ---
  Les services fournis par notre gouvernement jouent un rôle important dans la vie de millions de gens.
 

--- a/content/fr/blog/posts/reduire-le-risque-grace-au-deploiement-continu.md
+++ b/content/fr/blog/posts/reduire-le-risque-grace-au-deploiement-continu.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_continuous_deployment_69684377e
 image-alt: Un homme travaille à un bureau sur le code.
 translationKey: reducing-risk-through-continuous-deployment
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_continuous_deployment_69684377ec.jpg
+tags: [""]
 ---
 La plupart des ministères avec qui nous travaillons déploient de nouvelles versions de leur code tous les 4, 6 ou 12 mois. Cette façon de faire cadre bien avec le processus de [développement de logiciel en cascade](https://cyclededeveloppementdunlogiciel.wordpress.com/le-modele-en-cascade/), souvent accompagné de sérieux risques.
 

--- a/content/fr/blog/posts/remettre-en-question.md
+++ b/content/fr/blog/posts/remettre-en-question.md
@@ -12,6 +12,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_accessibility_2018_52c1550c88.j
 image-alt: Clavier avec des touches représentant des fonctionnalités d'accessibilité
 translationKey: challenging-our-assumption
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_accessibility_2018_52c1550c88.jpg
+tags: [""]
 ---
 
 Nous avons récemment reçu des commentaires sur notre [référentiel Github](https://github.com/cds-snc/digital-canada-ca) concernant l'accessibilité des images de premier plan utilisées sur certaines pages de notre site Web, y compris sur notre blogue.

--- a/content/fr/blog/posts/remue-méninges-en-équipe-durant-la-semaine-d’idéation-c’est-peut-être-une-idée-terrible-mais….md
+++ b/content/fr/blog/posts/remue-méninges-en-équipe-durant-la-semaine-d’idéation-c’est-peut-être-une-idée-terrible-mais….md
@@ -15,6 +15,7 @@ image-alt: >-
   tirées au-dessus de leur tête.
 translationKey: brainstorming-ideation-week
 thumb: https://de2an9clyit2x.cloudfront.net/small_ideas_7f6ab400e5.jpg
+tags: [""]
 ---
 Imaginez-vous au travail, debout devant votre équipe, en train de dire la pire idée que vous ayez jamais eue. Cela vous rend-il mal à l’aise? Nous avons été conditionnés à ne présenter que nos meilleures idées. Mais dire les pires idées possible est exactement ce que j’ai demandé à mon équipe au cours de notre dernière Semaine d’idéation. Permettez-moi d’expliquer pourquoi cet exercice « farfelu » était en fait une très bonne idée.
 

--- a/content/fr/blog/posts/rendre-les-informations-faciles-à-voir-et-à-entendre.md
+++ b/content/fr/blog/posts/rendre-les-informations-faciles-à-voir-et-à-entendre.md
@@ -17,6 +17,7 @@ image-alt: >-
   importante de son ordinateur.
 translationKey: blog-screenreader-stuff
 thumb: https://de2an9clyit2x.cloudfront.net/small_screenreader_blog_banner_5e9a928d1d.jpg
+tags: [""]
 ---
 ## Alerte COVID et codes de sauvegarde
 

--- a/content/fr/blog/posts/reporter-un-rendez-vous-dexamen.md
+++ b/content/fr/blog/posts/reporter-un-rendez-vous-dexamen.md
@@ -13,6 +13,7 @@ image-alt: >-
   au comptoir de service.
 translationKey: reschedule-a-citizenship-appointment
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_ircc_april_9f8d1d0bfb.jpg
+tags: [""]
 ---
 
 Notre partenariat avec [Immigration, Réfugiés et Citoyenneté Canada](https://www.canada.ca/fr/immigration-refugies-citoyennete.html) (IRCC) vise à ce que le processus de modification d’un rendez-vous d’examen de citoyenneté soit aussi pratique et facile que possible pour les demandeurs, tout en facilitant la vie au personnel de première ligne.

--- a/content/fr/blog/posts/retrospective-sur-lapi-denerguide.md
+++ b/content/fr/blog/posts/retrospective-sur-lapi-denerguide.md
@@ -15,6 +15,7 @@ image-alt: >-
   post-it ») sur le tableau blanc.
 translationKey: retrospective-on-energuide-api
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_energuide_retro_f4780d2e1d.jpg
+tags: [""]
 ---
 
 Alors que notre partenariat avec Ressources naturelles Canada (RNCan) pour l’API (interface de programmation d’applications) d’ÉnerGuide tire à sa fin, l’équipe de produit du Service numérique canadien (SNC) a tenu une rétrospective pour réfléchir à son expérience, à ses réalisations et aux leçons à retenir.

--- a/content/fr/blog/posts/réalisation-de-tests-par-interception-à-montréal.md
+++ b/content/fr/blog/posts/réalisation-de-tests-par-interception-à-montréal.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/field_note_train_0fc028062b.jpg
 image-alt: Photo en teinte orangée d’une locomotive.
 translationKey: field-note-1
 thumb: https://de2an9clyit2x.cloudfront.net/small_field_note_train_0fc028062b.jpg
+tags: [""]
 ---
 <p>Les notes de terrain sont un nouveau format de contenu du Service numérique canadien. Plus courtes qu’un billet de blogue, elles permettent aux équipes de livraison de donner des mises à jour plus régulières, de partager des observations plus modestes et de travailler ouvertement de façon continue.</p>
 

--- a/content/fr/blog/posts/réflexions-sur-un-service-au-bout-de-100-semaines.md
+++ b/content/fr/blog/posts/réflexions-sur-un-service-au-bout-de-100-semaines.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/banner_100_weeks_get_updates_fr_698b
 image-alt: A person researching GC Notify on their laptop and chatting on the phone with their manager about the tool.
 thumb: https://de2an9clyit2x.cloudfront.net/small_banner_100_weeks_get_updates_fr_698bacce89.jpg
 translationKey: blog-100-weeks-get-updates
+tags: [""]
 ---
 Le 7 mars 2022, nous avons franchi le cap des 100 semaines de vie du service [Obtenir les nouvelles sur la COVID-19](https://www.canada.ca/fr/service-web-gere/obtenez-nouvelles-covid-19.html), un service qui fournit aux Canadiennes et Canadiens des informations fiables et adaptées à leurs besoins. Nous avons franchi de nombreuses étapes importantes en cours de route : 8,5 millions de courriels envoyés, 364 000 visites du site Canada.ca à partir de nos courriels et plus de 100 000 abonnements au service en ligne.
 

--- a/content/fr/blog/posts/répondre-aux-besoins-des-autorités-sanitaires-pour-déployer-alerte-covid-partout-au-canada.md
+++ b/content/fr/blog/posts/répondre-aux-besoins-des-autorités-sanitaires-pour-déployer-alerte-covid-partout-au-canada.md
@@ -16,6 +16,7 @@ image-alt: >-
   santé dans diverses provinces et territoires.
 translationKey: healthcare-portal-service-design
 thumb: https://de2an9clyit2x.cloudfront.net/small_app_portal_blog_banner_dddd52ec15.jpg
+tags: [""]
 ---
 [Alerte COVID](https://www.canada.ca/fr/sante-publique/services/maladies/maladie-coronavirus-covid-19/alerte-covid.html), l’application gratuite de notification d’exposition à la COVID-19 du gouvernement du Canada, a été téléchargée par plus de 2 millions de personnes. Bien que l’application elle-même soit le point de contact avec le public, il se passe des choses en coulisses sans quoi elle ne fonctionnerait pas.
 

--- a/content/fr/blog/posts/se-mettre-a-niveau-au-sien-dune-equipe-agile.md
+++ b/content/fr/blog/posts/se-mettre-a-niveau-au-sien-dune-equipe-agile.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_up_to_speed_030a3f5cc5.jpg
 image-alt: Le tableau de bord d’une voiture avec l’indicateur de vitesse.
 translationKey: getting-up-to-speed
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_up_to_speed_030a3f5cc5.jpg
+tags: [""]
 ---
 
 Conduire le véhicule de quelqu’un d’autre peut parfois être un peu étrange. Il faut ajuster les rétroviseurs et repositionner les sièges et le volant pour assurer son confort. Ce n’est pas votre voiture, mais vous avez quand même une idée générale de l’endroit où les choses devraient être et de la façon dont elles devraient fonctionner. Il devrait en aller de même lorsqu’on se joint à une nouvelle équipe. Dès le départ, vous devriez être en mesure de comprendre assez rapidement le fonctionnement des choses. Se joindre à une nouvelle équipe ne devrait pas vous faire sentir comme si vous montiez dans un hélicoptère et qu’on vous demandait de le faire voler sans avoir reçu aucune formation.

--- a/content/fr/blog/posts/se-rencontrer-en-vrai-bâtit-la-confiance-d’une-équipe.md
+++ b/content/fr/blog/posts/se-rencontrer-en-vrai-bâtit-la-confiance-d’une-équipe.md
@@ -10,6 +10,7 @@ image: https://de2an9clyit2x.cloudfront.net/groupvac_cds_593fa30b36.jpg
 image-alt: Les membres de l’équipe sont rassemblés et sourient pour une photo.
 translationKey: VAC-CDS-visit
 thumb: https://de2an9clyit2x.cloudfront.net/small_groupvac_cds_593fa30b36.jpg
+tags: [""]
 ---
 En tant qu’analyste d’entreprise consultante à Anciens Combattants Canada (ACC) à Charlottetown, en partenariat avec le Service numérique canadien (SNC), il est difficile de participer à un projet en cours alors que les équipes sont situées dans différentes villes. Malgré nos mêlées quotidiennes à distance, nous ne faisons pas connaissance avec tout le monde, et il est difficile d’associer une voix à un nom sans s’être jamais rencontrés.
 

--- a/content/fr/blog/posts/sortir-les-prototypes.md
+++ b/content/fr/blog/posts/sortir-les-prototypes.md
@@ -13,6 +13,7 @@ image-alt: >-
   première version de l'application de breffage électronique.
 translationKey: getting-prototypes-out-the-door
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_ebriefing_2018_e3c77beee0.jpg
+tags: [""]
 ---
 
 Obtenir la rétroaction directe des utilisateurs est la meilleure façon d’améliorer un produit numérique. Toutes les activités comme les réunions stratégiques, la planification et la définition des exigences qui constituent les étapes typiques du développement d’un logiciel au gouvernement ne font pas le poids comparativement au véritable [test du produit par ses utilisateurs](https://medium.com/code-for-america/what-healthcare-gov-has-to-do-with-the-hawaii-false-alarm-and-what-to-do-about-it-445cb2b7af82).

--- a/content/fr/blog/posts/strategie-en-matiere-de-competences-mondiales.md
+++ b/content/fr/blog/posts/strategie-en-matiere-de-competences-mondiales.md
@@ -17,6 +17,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_global_skills_strategy_42ab3dc4
 image-alt: Une femme porte des chaussures argentées sur une plate-forme de métro.
 translationKey: global-skills-strategy
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_global_skills_strategy_42ab3dc4c1.jpg
+tags: [""]
 ---
 
 À mes débuts au Service numérique canadien (SNC), je pensais défis et possibilités, mais je n’avais jamais vraiment songé aux nouvelles routes que nous allions emprunter pour embaucher les meilleurs employés. Dans ce billet de blogue, je vais vous faire part de notre expérience de travail avec Immigration, Réfugiés et Citoyenneté Canada (IRCC) pour attirer des spécialistes du monde entier au SNC. J’aborderai plus particulièrement la façon dont nous avons utilisé la nouvelle Stratégie en matière de compétences mondiales pour embaucher notre premier membre de l’équipe à l’international.

--- a/content/fr/blog/posts/supporter-utilisateurs-degradation-progressive-react.md
+++ b/content/fr/blog/posts/supporter-utilisateurs-degradation-progressive-react.md
@@ -10,6 +10,7 @@ image-alt: >-
   ordinateur portable et une tour d’ordinateur de bureau.
 translationKey: supporting-users-gracefully-degrading-react
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_no_JS_16ec4cec0b.jpg
+tags: [""]
 ---
 
 Utiliser les technologies modernes peut rendre le développement plus rapide, mais, ultimement, nous devons livrer des solutions fonctionnelles sans sacrifier la robustesse et l’accessibilité. Nous avons créé le service pour « reporter un examen de citoyenneté » de sorte à repousser les limites de la prestation de services sans toutefois laisser les utilisateurs au dépourvu.

--- a/content/fr/blog/posts/tester-ses-hypothèses-avant-de-résoudre-des-problèmes.md
+++ b/content/fr/blog/posts/tester-ses-hypothèses-avant-de-résoudre-des-problèmes.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_banner_testing_security_assumpt
 image-alt: Une personne réfléchit à des questions et les approfondit, avant d'essayer d’y trouver des réponses.
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_banner_testing_security_assumptions_946d799a9a.jpeg
 translationKey: blog-testing-security-assumptions
+tags: [""]
 ---
 Résoudre un problème qui n'existe pas réellement, est-ce vraiment résoudre un problème? C’est peut-être ce qui se produit lorsque notre travail repose sur des hypothèses et qu’elles ne sont pas mises à l’épreuve. 
 

--- a/content/fr/blog/posts/tests-de-validation-une-façon-de-remettre-en-question-ses-hypothèses.md
+++ b/content/fr/blog/posts/tests-de-validation-une-façon-de-remettre-en-question-ses-hypothèses.md
@@ -15,6 +15,7 @@ image-alt: >-
   côte à côte dans des pots blancs et devant un fond blanc.
 translationKey: validation-testing-cra
 thumb: https://de2an9clyit2x.cloudfront.net/small_colourful_cactuses_34eab63a4d.jpg
+tags: [""]
 ---
 Placer les gens au centre de notre travail, c’est aussi avoir confiance qu’ils sont les experts de leur contexte et de leurs besoins.
 

--- a/content/fr/blog/posts/toujours-un-defi.md
+++ b/content/fr/blog/posts/toujours-un-defi.md
@@ -11,6 +11,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_toujours_un_defi_2017_930e45d8f
 image-alt: La page d’accueil de la plateforme de défis Impact Canada.
 translationKey: always-a-challenge
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_toujours_un_defi_2017_930e45d8f0.jpg
+tags: [""]
 ---
 Au cours de nos [séances de mobilisation](/commencement-de-la-conversation/rapport-complet/), les gens nous ont dit que le gouvernement devait trouver des façons de permettre aux joueurs non traditionnels de s’impliquer et de co-créer des solutions avec le gouvernement.
 

--- a/content/fr/blog/posts/une-équipe-renforcée-par-la-distance.md
+++ b/content/fr/blog/posts/une-équipe-renforcée-par-la-distance.md
@@ -14,6 +14,7 @@ image-alt: >-
   et à partir de lieux différents.
 translationKey: distributed-pm
 thumb: https://de2an9clyit2x.cloudfront.net/small_distributed_pm_blog_c8f11db928.jpg
+tags: [""]
 ---
 Je suis arrivé au Service numérique canadien (SNC) par une froide journée de janvier. Je me suis rendu au bureau d’Ottawa pour une période d’intégration de deux semaines, après quoi je devais retourner chez moi, à Kitchener-Waterloo, où il fait *un peu moins* froid, pour travailler à temps plein.
 

--- a/content/fr/blog/posts/utiliser-les-données-pour-répondre-aux-besoins-d’information-pendant-la-pandémie.md
+++ b/content/fr/blog/posts/utiliser-les-données-pour-répondre-aux-besoins-d’information-pendant-la-pandémie.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/HC_Get_Updates_f9a9c93d65.jpg
 image-alt: Une énorme quantité de données provenant de différentes sources sont canalisées dans un seul courriel facile à digérer. 
 thumb: https://de2an9clyit2x.cloudfront.net/small_HC_Get_Updates_f9a9c93d65.jpg
 translationKey: blog-data-healthcanada-notify
+tags: [""]
 ---
 ## Surcharge d’informations
 

--- a/content/fr/blog/posts/voir-grand-commencer-modestement.md
+++ b/content/fr/blog/posts/voir-grand-commencer-modestement.md
@@ -14,6 +14,7 @@ image-alt: >-
   pouce vers le haut.
 translationKey: think-big-start-small
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_think_big_start_small_2017_2764703473.jpg
+tags: [""]
 ---
 Le Government Digital Service (GDS) du Royaume-Uni a une remarquable liste de [dix principes de conception](https://www.gov.uk/design-principles). Je me souviens encore de la première fois où je l’ai vue. On peut y lire «&nbsp;Commencez par les besoins des utilisateurs, pas par les besoins du gouvernement&nbsp;». Oh mon dieu, me suis-je dit : il s’agit d’un vrai site Web du gouvernement du Royaume-Uni. C’est incroyable!
 

--- a/content/fr/blog/posts/yolo-plutôt-colocalisation-nest-ce-pas.md
+++ b/content/fr/blog/posts/yolo-plutôt-colocalisation-nest-ce-pas.md
@@ -14,6 +14,7 @@ image-alt: >-
   d’Ottawa.
 translationKey: keith-rcmp-blog
 thumb: https://de2an9clyit2x.cloudfront.net/small_keith_rcmp_blog_66ebe05132.jpg
+tags: [""]
 ---
 Oh là là. Je suis en réunion, à répondre aux questions du dirigeant principal de l’information (DPI) de la GRC. **Le D-P-I.** Au cours de ma carrière de presque 20 ans dans la fonction publique, cette situation ne s’est jamais produite. Cependant me voici, moi, un développeur de la Gendarmerie royale du Canada (GRC), en colocalisation au Service numérique canadien (SNC) pour travailler sur un outil de signalement public destiné aux victimes de cybercrimes, plaidant pour des changements directement au DPI. Il y a 14 mois, cette situation aurait été tout à fait inconcevable.
 

--- a/content/fr/blog/posts/«-parfait-ou-presque-»-:-gestion-d’incidents-au-snc.md
+++ b/content/fr/blog/posts/«-parfait-ou-presque-»-:-gestion-d’incidents-au-snc.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/banner_a_percentage_of_perfection_in
 image-alt: Un ordinateur portable avec un écran rouge entouré de panneaux de danger, d'un sablier, d'une icône de paramètres et d'une bouée de sauvetage.
 thumb: https://de2an9clyit2x.cloudfront.net/small_banner_a_percentage_of_perfection_incident_management_at_cds_f2f8ea5925.jpeg
 translationKey: security-incident-management-cds
+tags: [""]
 ---
 > *« Accepter que les choses imparfaites puissent quand même fonctionner est essentiel pour éviter que les échecs ne deviennent des catastrophes. »*
 

--- a/content/fr/blog/posts/« bouchées-de-sécurité »-au-snc.md
+++ b/content/fr/blog/posts/« bouchées-de-sécurité »-au-snc.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/banner_security_snack_time_a5cd2fbf1
 image-alt: Un beigne partiellement mangé, un cadenas, une tasse de café et une souris d’ordinateur.
 thumb: https://de2an9clyit2x.cloudfront.net/small_banner_security_snack_time_a5cd2fbf11.jpg
 translationKey: blog-security-snack-time
+tags: [""]
 ---
 Qu’est-ce qui vous vient à l’esprit lorsque vous entendez « formation en sécurité informatique »? 
 

--- a/content/fr/blog/posts/à-l’écoute-des-utilisateurs-amélioration-de-l’outil-de-recherche-de-prestations-liées-à-la-covid-19.md
+++ b/content/fr/blog/posts/à-l’écoute-des-utilisateurs-amélioration-de-l’outil-de-recherche-de-prestations-liées-à-la-covid-19.md
@@ -16,6 +16,7 @@ image-alt: >-
   utilisabilité de la part de 8 personnes différentes.
 translationKey: blog-ffhc19-feedback
 thumb: https://de2an9clyit2x.cloudfront.net/small_adrianne_blog_fr_bf220fb4f8.jpg
+tags: [""]
 ---
 Le 7 mai, nous avons lancé discrètement l’outil en ligne « [Trouver de l’aide financière pendant la COVID-19](https://covid-prestations.alpha.canada.ca/fr/debut) », en partenariat avec Service Canada. Le but de cet outil codéveloppé est de réduire le stress financier que subissent les Canadiens et les Canadiennes pendant la pandémie. En demandant aux gens de répondre à quelques questions simples de façon anonyme, l’outil leur fournit une liste de prestations adaptée à leur situation. La zone de commentaires que nous y avons incluse a eu une incidence considérable sur notre capacité à améliorer l’outil, grâce aux gens qui l’ont utilisée chaque jour.
 

--- a/content/fr/blog/posts/élaborer-un-cadre-d’évaluation-pour-la-prestation-des-produits-et-services.md
+++ b/content/fr/blog/posts/élaborer-un-cadre-d’évaluation-pour-la-prestation-des-produits-et-services.md
@@ -15,6 +15,7 @@ image-alt: Quatre cadres noirs et sans photo sont accrochés côte à côte sur 
 translationKey: evaluation-framework
 thumb: https://de2an9clyit2x.cloudfront.net/small_four_frames_f2c06871f1.jpg
 
+tags: [""]
 ---
  Si vous êtes une personne qui suivez les activités du SNC ou qui travaillez avec ce dernier, vous êtes probablement intéressée par la façon dont nous évaluons le succès de nos produits et partenariats.
 

--- a/content/fr/blog/posts/évaluer-les-besoins-en-formation-du-gouvernement-pour-l’avenir-de-la-prestation-de-services-numériques.md
+++ b/content/fr/blog/posts/évaluer-les-besoins-en-formation-du-gouvernement-pour-l’avenir-de-la-prestation-de-services-numériques.md
@@ -21,6 +21,7 @@ image-alt: >-
   portables et des papillons adhésifs, à l’occasion d’un atelier.
 translationKey: assessing-training-needs
 thumb: https://de2an9clyit2x.cloudfront.net/small_tna_image_cfa9a36c02.jpg
+tags: [""]
 ---
 Alors que le gouvernement du Canada (GC) s’efforce d’améliorer sa façon de concevoir et d’offrir des services, il est possible d’envisager de nouveaux outils, méthodes et pratiques pour renforcer notre capacité à y parvenir. Mais les gens — les fonctionnaires — demeurent au cœur de ces efforts. Ainsi, lorsque nous avons [fait équipe](/2018/11/01/chers-collègues-quelle-est-la-formation-numérique-dont-vous-avez-besoin/) avec la Faculté de gestion de l’Université Dalhousie, à la fin de l’année dernière, pour mieux comprendre et évaluer les besoins actuels en formation dans les disciplines numériques à l’échelle du GC, nous avons commencé par consulter les fonctionnaires. Communiquer directement avec eux nous a permis de mieux comprendre leurs besoins et la façon dont nous pouvons y répondre. Le rapport complet se trouve sur [le site Web de l’Université Dalhousie](https://bit.ly/2NHBVyG).
 

--- a/content/fr/blog/posts/êtes-vous-notre-pdg-de-demain?.md
+++ b/content/fr/blog/posts/êtes-vous-notre-pdg-de-demain?.md
@@ -9,6 +9,7 @@ image: https://de2an9clyit2x.cloudfront.net/blog_next_ceo_banner_fr_d6defdafec.j
 image-alt: Un téléphone intelligent posé à côté d’un livre indiquant « Le  chapitre suivant » pour le Service numérique canadien.
 thumb: https://de2an9clyit2x.cloudfront.net/small_blog_next_ceo_banner_fr_d6defdafec.jpg
 translationKey: blog-ceo-job-search
+tags: [""]
 ---
 Au Service numérique canadien, notre mission est de changer le gouvernement pour mieux servir les gens. Ce n’est pas une mince affaire, mais nous savons que d’autres partagent notre obsession de simplifier les services gouvernementaux. Nous sommes à la recherche de notre PDG de demain, qui nous aidera à évoluer en matière de croissance comme d’impact. Nous cherchons quelqu’un qui saura [soutenir les fonctionnaires](https://digital.canada.ca/roadmap-2025/) et permettre à l’ensemble du gouvernement de développer des logiciels et de fournir des services de façon moderne. Si vous vous reconnaissez dans cette description, nous adorerions recevoir votre candidature.
 

--- a/content/fr/blog/posts/être-tout-oreilles-pour-utiliser-les-mêmes-mots-que-les-gens.md
+++ b/content/fr/blog/posts/être-tout-oreilles-pour-utiliser-les-mêmes-mots-que-les-gens.md
@@ -17,6 +17,7 @@ image-alt: >-
 translationKey: using-words-people-use
 thumb: https://de2an9clyit2x.cloudfront.net/small_bag_and_hands_62d7b020be.jpg
 
+tags: [""]
 ---
 La façon dont le gouvernement s’exprime peut être très différente de la façon dont les gens s’expriment à l’extérieur du gouvernement. En tant que fonctionnaire, je sais qu’il m’est arrivé d’utiliser un langage spécialisé qui perd son sens en dehors de mon équipe ou de mon ministère. Mais j’ai aussi été de l’autre côté, perdue en essayant de naviguer dans un site Web du gouvernement ou frustrée en cherchant différentes combinaisons de mots pour trouver le bon formulaire.
 

--- a/content/fr/blog/posts/être-un-étudiant-en-stage-au-snc-m’a-appris-à-me-faire-confiance.md
+++ b/content/fr/blog/posts/être-un-étudiant-en-stage-au-snc-m’a-appris-à-me-faire-confiance.md
@@ -15,6 +15,7 @@ image-alt: >-
   stylo blanc, une pomme et un haut-parleur portatif.
 translationKey: cds-student-trust
 thumb: https://de2an9clyit2x.cloudfront.net/small_jose_blog_header_8527c435f6.jpg
+tags: [""]
 ---
 _En repensant aux huit mois que j’ai passés comme étudiant en stage au Service numérique canadien (SNC), j’ai appris que le renforcement de l’autonomie est une question de confiance : la confiance de la part de ses gestionnaires et, surtout, la confiance en soi._
 


### PR DESCRIPTION
# Summary | Résumé

Basically just added "tags: [""]" to all the strapi blog posts instead of having to do it manually.