### PR TITLE
chore: update to new design system domain

### DIFF
--- a/content/en/our-products/gc-design-system.md
+++ b/content/en/our-products/gc-design-system.md
@@ -3,6 +3,6 @@ title: 'GC Design System'
 description: Design consistent web experiences.
 image: '/img/cds/gc-design-systems.svg'
 imageAlt: 'Screenshot of GC Design System'
-link: 'https://design-system.alpha.canada.ca/en/'
+link: 'https://design-system.canada.ca/en/'
 weight: 4
 ---

--- a/content/fr/our-products/système-de-design-gc.md
+++ b/content/fr/our-products/système-de-design-gc.md
@@ -3,6 +3,6 @@ title: 'Système de design GC'
 description: Composants réutilisables conformes aux normes du Web.
 image: '/img/cds/fr-gc-design-system.svg'
 imageAlt: 'Capture d’écran de Système de design GC.'
-link: 'https://systeme-design.alpha.canada.ca/fr/'
+link: 'https://systeme-design.canada.ca/fr/'
 weight: 4
 ---


### PR DESCRIPTION
# Summary | Résumé

With the `v1.0.0` release of the GC Design System, the design system's domain has been updated an dropped the `alpha` subdomain. This updates the CDS website to use the new domain for GCDS.

https://github.com/cds-snc/design-gc-conception/issues/2245
